### PR TITLE
Simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,22 @@
 CC = g++
 CFLAGS = -Wall -I. -I./sam -I./boost -L./sam
 COFLAGS = -O3 -ffast-math -c
-PROGRAMS = rsem-extract-reference-transcripts rsem-synthesis-reference-transcripts rsem-preref rsem-parse-alignments rsem-build-read-index rsem-run-em rsem-tbam2gbam rsem-run-gibbs rsem-calculate-credibility-intervals rsem-simulate-reads rsem-bam2wig rsem-get-unique rsem-bam2readdepth rsem-sam-validator rsem-scan-for-paired-end-reads
+PROGRAMS = \
+  rsem-extract-reference-transcripts \
+  rsem-synthesis-reference-transcripts \
+  rsem-preref \
+  rsem-parse-alignments \
+  rsem-build-read-index \
+  rsem-run-em \
+  rsem-tbam2gbam \
+  rsem-run-gibbs \
+  rsem-calculate-credibility-intervals \
+  rsem-simulate-reads \
+  rsem-bam2wig \
+  rsem-get-unique \
+  rsem-bam2readdepth \
+  rsem-sam-validator \
+  rsem-scan-for-paired-end-reads
 
 .PHONY : all ebseq clean
 

--- a/Makefile
+++ b/Makefile
@@ -15,71 +15,71 @@ ebseq :
 
 
 calcCI.o : calcCI.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) calcCI.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) $<
 
 EM.o : EM.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) EM.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) $<
 
 Gibbs.o : Gibbs.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) Gibbs.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) $<
 
 preRef.o : preRef.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) preRef.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) $<
 
 parseIt.o : parseIt.cpp
-	$(CC) $(CFLAGS) -O2 -c parseIt.cpp
+	$(CC) $(CFLAGS) -O2 -c $<
 
 simulation.o : simulation.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) simulation.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) $<
 
 wiggle.o: wiggle.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) wiggle.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) $<
 
 
 rsem-extract-reference-transcripts : extractRef.cpp
-	$(CC) $(CFLAGS) -O3 extractRef.cpp -o $@
+	$(CC) $(CFLAGS) -O3 $< -o $@
 
 rsem-synthesis-reference-transcripts : synthesisRef.cpp
-	$(CC) $(CFLAGS) -O3 synthesisRef.cpp -o $@
+	$(CC) $(CFLAGS) -O3 $< -o $@
 
 rsem-preref : preRef.o
-	$(CC) $(CFLAGS) preRef.o -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 rsem-parse-alignments : parseIt.o
-	$(CC) $(CFLAGS) -o $@ parseIt.o -lbam -lz -lpthread
+	$(CC) $(CFLAGS) -o $@ $< -lbam -lz -lpthread
 
 rsem-build-read-index : buildReadIndex.cpp
-	$(CC) $(CFLAGS) -O3 buildReadIndex.cpp -o $@
+	$(CC) $(CFLAGS) -O3 $< -o $@
 
 rsem-run-em : EM.o
-	$(CC) $(CFLAGS) -o $@ EM.o -lbam -lz -lpthread
+	$(CC) $(CFLAGS) -o $@ $< -lbam -lz -lpthread
 
 rsem-tbam2gbam : tbam2gbam.cpp
-	$(CC) $(CFLAGS) -O3 tbam2gbam.cpp -lbam -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 $< -lbam -lz -lpthread -o $@
 
 rsem-bam2wig : wiggle.o bam2wig.cpp
-	$(CC) $(CFLAGS) -O3 bam2wig.cpp wiggle.o -lbam -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 $^ -lbam -lz -lpthread -o $@
 
 rsem-bam2readdepth : wiggle.o bam2readdepth.cpp
-	$(CC) $(CFLAGS) -O3 bam2readdepth.cpp wiggle.o -lbam -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 $^ -lbam -lz -lpthread -o $@
 
 rsem-simulate-reads : simulation.o
-	$(CC) $(CFLAGS) -o $@ simulation.o
+	$(CC) $(CFLAGS) -o $@ $<
 
 rsem-run-gibbs : Gibbs.o
-	$(CC) $(CFLAGS) -o $@ Gibbs.o -lpthread
+	$(CC) $(CFLAGS) -o $@ $< -lpthread
 
 rsem-calculate-credibility-intervals : calcCI.o
-	$(CC) $(CFLAGS) -o $@ calcCI.o -lpthread
+	$(CC) $(CFLAGS) -o $@ $< -lpthread
 
 rsem-get-unique : getUnique.cpp
-	$(CC) $(CFLAGS) -O3 getUnique.cpp -lbam -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 $< -lbam -lz -lpthread -o $@
 
 rsem-sam-validator : samValidator.cpp
-	$(CC) $(CFLAGS) -O3 samValidator.cpp -lbam -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 $< -lbam -lz -lpthread -o $@
 
 rsem-scan-for-paired-end-reads : scanForPairedEndReads.cpp
-	$(CC) $(CFLAGS) -O3 scanForPairedEndReads.cpp -lbam -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 $< -lbam -lz -lpthread -o $@
 
 clean :
 	rm -f *.o *~ $(PROGRAMS)

--- a/Makefile
+++ b/Makefile
@@ -10,133 +10,70 @@ all : $(PROGRAMS)
 sam/libbam.a :
 	cd sam ; ${MAKE} all
 
-Transcript.h : utils.h
-
-Transcripts.h : utils.h my_assert.h Transcript.h
-
-rsem-extract-reference-transcripts : utils.h my_assert.h GTFItem.h Transcript.h Transcripts.h extractRef.cpp
+rsem-extract-reference-transcripts : extractRef.cpp
 	$(CC) -Wall -O3 extractRef.cpp -o rsem-extract-reference-transcripts
 
-rsem-synthesis-reference-transcripts : utils.h my_assert.h Transcript.h Transcripts.h synthesisRef.cpp
+rsem-synthesis-reference-transcripts : synthesisRef.cpp
 	$(CC) -Wall -O3 synthesisRef.cpp -o rsem-synthesis-reference-transcripts
-
-BowtieRefSeqPolicy.h : RefSeqPolicy.h
-
-RefSeq.h : utils.h
-
-Refs.h : utils.h RefSeq.h RefSeqPolicy.h PolyARules.h
-
 
 rsem-preref : preRef.o
 	$(CC) preRef.o -o rsem-preref
 
-preRef.o : utils.h RefSeq.h Refs.h PolyARules.h RefSeqPolicy.h AlignerRefSeqPolicy.h preRef.cpp
+preRef.o : preRef.cpp
 	$(CC) $(COFLAGS) preRef.cpp
-
-
-SingleRead.h : Read.h
-
-SingleReadQ.h : Read.h
-
-PairedEndRead.h : Read.h SingleRead.h
-
-PairedEndReadQ.h : Read.h SingleReadQ.h
-
-
-PairedEndHit.h : SingleHit.h
-
-HitContainer.h : GroupInfo.h
-
-
-SamParser.h : sam/sam.h sam/bam.h utils.h my_assert.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Transcripts.h
-
 
 rsem-parse-alignments : parseIt.o sam/libbam.a
 	$(CC) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz -lpthread 
 
-parseIt.o : utils.h GroupInfo.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h HitContainer.h SamParser.h Transcripts.h sam/sam.h sam/bam.h parseIt.cpp
+parseIt.o : parseIt.cpp
 	$(CC) -Wall -O2 -c -I. parseIt.cpp
 
-
-rsem-build-read-index : utils.h buildReadIndex.cpp
+rsem-build-read-index : buildReadIndex.cpp
 	$(CC) -O3 buildReadIndex.cpp -o rsem-build-read-index
-
-
-simul.h : boost/random.hpp
-
-ReadReader.h : SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h ReadIndex.h
-
-SingleModel.h : utils.h my_assert.h Orientation.h LenDist.h RSPD.h Profile.h NoiseProfile.h ModelParams.h RefSeq.h Refs.h SingleRead.h SingleHit.h ReadReader.h simul.h
-
-SingleQModel.h : utils.h my_assert.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h ModelParams.h RefSeq.h Refs.h SingleReadQ.h SingleHit.h ReadReader.h simul.h
-
-PairedEndModel.h : utils.h my_assert.h Orientation.h LenDist.h RSPD.h Profile.h NoiseProfile.h ModelParams.h RefSeq.h Refs.h SingleRead.h PairedEndRead.h PairedEndHit.h ReadReader.h simul.h 
-
-PairedEndQModel.h : utils.h my_assert.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h ModelParams.h RefSeq.h Refs.h SingleReadQ.h PairedEndReadQ.h PairedEndHit.h ReadReader.h simul.h
-
-HitWrapper.h : HitContainer.h
-
-sam_rsem_aux.h : sam/bam.h
-
-sam_rsem_cvt.h : sam/bam.h Transcript.h Transcripts.h
-
-BamWriter.h : sam/sam.h sam/bam.h sam_rsem_aux.h sam_rsem_cvt.h SingleHit.h PairedEndHit.h HitWrapper.h Transcript.h Transcripts.h
-
-sampling.h : boost/random.hpp
-
-WriteResults.h : utils.h my_assert.h GroupInfo.h Transcript.h Transcripts.h RefSeq.h Refs.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h
 
 rsem-run-em : EM.o sam/libbam.a
 	$(CC) -o rsem-run-em EM.o sam/libbam.a -lz -lpthread
 
-EM.o : utils.h my_assert.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h Refs.h GroupInfo.h HitContainer.h ReadIndex.h ReadReader.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h ModelParams.h RefSeq.h RefSeqPolicy.h PolyARules.h Profile.h NoiseProfile.h Transcript.h Transcripts.h HitWrapper.h BamWriter.h sam/bam.h sam/sam.h simul.h sam_rsem_aux.h sampling.h boost/random.hpp WriteResults.h EM.cpp
+EM.o : EM.cpp
 	$(CC) $(COFLAGS) EM.cpp
 
-bc_aux.h : sam/bam.h
-
-BamConverter.h : utils.h my_assert.h sam/sam.h sam/bam.h sam_rsem_aux.h sam_rsem_cvt.h bc_aux.h Transcript.h Transcripts.h
-
-rsem-tbam2gbam : utils.h Transcripts.h Transcript.h bc_aux.h BamConverter.h sam/sam.h sam/bam.h sam/libbam.a sam_rsem_aux.h sam_rsem_cvt.h tbam2gbam.cpp sam/libbam.a
+rsem-tbam2gbam : tbam2gbam.cpp sam/libbam.a
 	$(CC) -O3 -Wall tbam2gbam.cpp sam/libbam.a -lz -lpthread -o $@
 
-rsem-bam2wig : utils.h my_assert.h wiggle.h wiggle.o sam/libbam.a bam2wig.cpp
+rsem-bam2wig : wiggle.o sam/libbam.a bam2wig.cpp
 	$(CC) -O3 -Wall bam2wig.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
 
-rsem-bam2readdepth : utils.h my_assert.h wiggle.h wiggle.o sam/libbam.a bam2readdepth.cpp
+rsem-bam2readdepth : wiggle.o sam/libbam.a bam2readdepth.cpp
 	$(CC) -O3 -Wall bam2readdepth.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
 
-wiggle.o: sam/bam.h sam/sam.h wiggle.cpp wiggle.h
+wiggle.o: wiggle.cpp
 	$(CC) $(COFLAGS) wiggle.cpp
 
 rsem-simulate-reads : simulation.o
 	$(CC) -o rsem-simulate-reads simulation.o
 
-simulation.o : utils.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h Refs.h RefSeq.h GroupInfo.h Transcript.h Transcripts.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h Profile.h NoiseProfile.h simul.h boost/random.hpp WriteResults.h simulation.cpp
+simulation.o : simulation.cpp
 	$(CC) $(COFLAGS) simulation.cpp
 
 rsem-run-gibbs : Gibbs.o
 	$(CC) -o rsem-run-gibbs Gibbs.o -lpthread
 
-#some header files are omitted
-Gibbs.o : utils.h my_assert.h boost/random.hpp sampling.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h RefSeq.h RefSeqPolicy.h PolyARules.h Refs.h GroupInfo.h WriteResults.h Gibbs.cpp 
+Gibbs.o : Gibbs.cpp
 	$(CC) $(COFLAGS) Gibbs.cpp
-
-Buffer.h : my_assert.h
 
 rsem-calculate-credibility-intervals : calcCI.o
 	$(CC) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
 
-#some header files are omitted
-calcCI.o : utils.h my_assert.h boost/random.hpp sampling.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h RefSeq.h RefSeqPolicy.h PolyARules.h Refs.h GroupInfo.h WriteResults.h Buffer.h calcCI.cpp
+calcCI.o : calcCI.cpp
 	$(CC) $(COFLAGS) calcCI.cpp
 
-rsem-get-unique : sam/bam.h sam/sam.h getUnique.cpp sam/libbam.a
+rsem-get-unique : getUnique.cpp sam/libbam.a
 	$(CC) -O3 -Wall getUnique.cpp sam/libbam.a -lz -lpthread -o $@
 
-rsem-sam-validator : sam/bam.h sam/sam.h my_assert.h samValidator.cpp sam/libbam.a
+rsem-sam-validator : samValidator.cpp sam/libbam.a
 	$(CC) -O3 -Wall samValidator.cpp sam/libbam.a -lz -lpthread -o $@
 
-rsem-scan-for-paired-end-reads : sam/bam.h sam/sam.h my_assert.h scanForPairedEndReads.cpp sam/libbam.a
+rsem-scan-for-paired-end-reads : scanForPairedEndReads.cpp sam/libbam.a
 	$(CC) -O3 -Wall scanForPairedEndReads.cpp sam/libbam.a -lz -lpthread -o $@
 
 ebseq :

--- a/Makefile
+++ b/Makefile
@@ -37,22 +37,22 @@ wiggle.o: wiggle.cpp
 
 
 rsem-extract-reference-transcripts : extractRef.cpp
-	$(CC) $(CFLAGS) -O3 extractRef.cpp -o rsem-extract-reference-transcripts
+	$(CC) $(CFLAGS) -O3 extractRef.cpp -o $@
 
 rsem-synthesis-reference-transcripts : synthesisRef.cpp
-	$(CC) $(CFLAGS) -O3 synthesisRef.cpp -o rsem-synthesis-reference-transcripts
+	$(CC) $(CFLAGS) -O3 synthesisRef.cpp -o $@
 
 rsem-preref : preRef.o
-	$(CC) $(CFLAGS) preRef.o -o rsem-preref
+	$(CC) $(CFLAGS) preRef.o -o $@
 
 rsem-parse-alignments : parseIt.o
-	$(CC) $(CFLAGS) -o rsem-parse-alignments parseIt.o -lbam -lz -lpthread
+	$(CC) $(CFLAGS) -o $@ parseIt.o -lbam -lz -lpthread
 
 rsem-build-read-index : buildReadIndex.cpp
-	$(CC) $(CFLAGS) -O3 buildReadIndex.cpp -o rsem-build-read-index
+	$(CC) $(CFLAGS) -O3 buildReadIndex.cpp -o $@
 
 rsem-run-em : EM.o
-	$(CC) $(CFLAGS) -o rsem-run-em EM.o -lbam -lz -lpthread
+	$(CC) $(CFLAGS) -o $@ EM.o -lbam -lz -lpthread
 
 rsem-tbam2gbam : tbam2gbam.cpp
 	$(CC) $(CFLAGS) -O3 tbam2gbam.cpp -lbam -lz -lpthread -o $@
@@ -64,13 +64,13 @@ rsem-bam2readdepth : wiggle.o bam2readdepth.cpp
 	$(CC) $(CFLAGS) -O3 bam2readdepth.cpp wiggle.o -lbam -lz -lpthread -o $@
 
 rsem-simulate-reads : simulation.o
-	$(CC) $(CFLAGS) -o rsem-simulate-reads simulation.o
+	$(CC) $(CFLAGS) -o $@ simulation.o
 
 rsem-run-gibbs : Gibbs.o
-	$(CC) $(CFLAGS) -o rsem-run-gibbs Gibbs.o -lpthread
+	$(CC) $(CFLAGS) -o $@ Gibbs.o -lpthread
 
 rsem-calculate-credibility-intervals : calcCI.o
-	$(CC) $(CFLAGS) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
+	$(CC) $(CFLAGS) -o $@ calcCI.o -lpthread
 
 rsem-get-unique : getUnique.cpp
 	$(CC) $(CFLAGS) -O3 getUnique.cpp -lbam -lz -lpthread -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 CC = g++
-CFLAGS = -Wall -I. -I./sam -I./boost
+CFLAGS = -Wall -I. -I./sam -I./boost -L./sam
 COFLAGS = -O3 -ffast-math -c
 PROGRAMS = rsem-extract-reference-transcripts rsem-synthesis-reference-transcripts rsem-preref rsem-parse-alignments rsem-build-read-index rsem-run-em rsem-tbam2gbam rsem-run-gibbs rsem-calculate-credibility-intervals rsem-simulate-reads rsem-bam2wig rsem-get-unique rsem-bam2readdepth rsem-sam-validator rsem-scan-for-paired-end-reads
 
 .PHONY : all ebseq clean
 
-all : $(PROGRAMS)
+all : sam/libbam.a $(PROGRAMS)
 
 sam/libbam.a :
 	cd sam ; ${MAKE} all
@@ -45,23 +45,23 @@ rsem-synthesis-reference-transcripts : synthesisRef.cpp
 rsem-preref : preRef.o
 	$(CC) $(CFLAGS) preRef.o -o rsem-preref
 
-rsem-parse-alignments : parseIt.o sam/libbam.a
-	$(CC) $(CFLAGS) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz -lpthread
+rsem-parse-alignments : parseIt.o
+	$(CC) $(CFLAGS) -o rsem-parse-alignments parseIt.o -lbam -lz -lpthread
 
 rsem-build-read-index : buildReadIndex.cpp
 	$(CC) $(CFLAGS) -O3 buildReadIndex.cpp -o rsem-build-read-index
 
-rsem-run-em : EM.o sam/libbam.a
-	$(CC) $(CFLAGS) -o rsem-run-em EM.o sam/libbam.a -lz -lpthread
+rsem-run-em : EM.o
+	$(CC) $(CFLAGS) -o rsem-run-em EM.o -lbam -lz -lpthread
 
-rsem-tbam2gbam : tbam2gbam.cpp sam/libbam.a
-	$(CC) $(CFLAGS) -O3 tbam2gbam.cpp sam/libbam.a -lz -lpthread -o $@
+rsem-tbam2gbam : tbam2gbam.cpp
+	$(CC) $(CFLAGS) -O3 tbam2gbam.cpp -lbam -lz -lpthread -o $@
 
-rsem-bam2wig : wiggle.o sam/libbam.a bam2wig.cpp
-	$(CC) $(CFLAGS) -O3 bam2wig.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
+rsem-bam2wig : wiggle.o bam2wig.cpp
+	$(CC) $(CFLAGS) -O3 bam2wig.cpp wiggle.o -lbam -lz -lpthread -o $@
 
-rsem-bam2readdepth : wiggle.o sam/libbam.a bam2readdepth.cpp
-	$(CC) $(CFLAGS) -O3 bam2readdepth.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
+rsem-bam2readdepth : wiggle.o bam2readdepth.cpp
+	$(CC) $(CFLAGS) -O3 bam2readdepth.cpp wiggle.o -lbam -lz -lpthread -o $@
 
 rsem-simulate-reads : simulation.o
 	$(CC) $(CFLAGS) -o rsem-simulate-reads simulation.o
@@ -72,14 +72,14 @@ rsem-run-gibbs : Gibbs.o
 rsem-calculate-credibility-intervals : calcCI.o
 	$(CC) $(CFLAGS) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
 
-rsem-get-unique : getUnique.cpp sam/libbam.a
-	$(CC) $(CFLAGS) -O3 getUnique.cpp sam/libbam.a -lz -lpthread -o $@
+rsem-get-unique : getUnique.cpp
+	$(CC) $(CFLAGS) -O3 getUnique.cpp -lbam -lz -lpthread -o $@
 
-rsem-sam-validator : samValidator.cpp sam/libbam.a
-	$(CC) $(CFLAGS) -O3 samValidator.cpp sam/libbam.a -lz -lpthread -o $@
+rsem-sam-validator : samValidator.cpp
+	$(CC) $(CFLAGS) -O3 samValidator.cpp -lbam -lz -lpthread -o $@
 
-rsem-scan-for-paired-end-reads : scanForPairedEndReads.cpp sam/libbam.a
-	$(CC) $(CFLAGS) -O3 scanForPairedEndReads.cpp sam/libbam.a -lz -lpthread -o $@
+rsem-scan-for-paired-end-reads : scanForPairedEndReads.cpp
+	$(CC) $(CFLAGS) -O3 scanForPairedEndReads.cpp -lbam -lz -lpthread -o $@
 
 clean :
 	rm -f *.o *~ $(PROGRAMS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = g++
-CFLAGS = -Wall -c -I.
-COFLAGS = -Wall -O3 -ffast-math -c -I.
+CFLAGS = -Wall -I. -I./sam -I./boost
+COFLAGS = -O3 -ffast-math -c
 PROGRAMS = rsem-extract-reference-transcripts rsem-synthesis-reference-transcripts rsem-preref rsem-parse-alignments rsem-build-read-index rsem-run-em rsem-tbam2gbam rsem-run-gibbs rsem-calculate-credibility-intervals rsem-simulate-reads rsem-bam2wig rsem-get-unique rsem-bam2readdepth rsem-sam-validator rsem-scan-for-paired-end-reads
 
 .PHONY : all ebseq clean
@@ -11,70 +11,70 @@ sam/libbam.a :
 	cd sam ; ${MAKE} all
 
 rsem-extract-reference-transcripts : extractRef.cpp
-	$(CC) -Wall -O3 extractRef.cpp -o rsem-extract-reference-transcripts
+	$(CC) $(CFLAGS) -O3 extractRef.cpp -o rsem-extract-reference-transcripts
 
 rsem-synthesis-reference-transcripts : synthesisRef.cpp
-	$(CC) -Wall -O3 synthesisRef.cpp -o rsem-synthesis-reference-transcripts
+	$(CC) $(CFLAGS) -O3 synthesisRef.cpp -o rsem-synthesis-reference-transcripts
 
 rsem-preref : preRef.o
-	$(CC) preRef.o -o rsem-preref
+	$(CC) $(CFLAGS) preRef.o -o rsem-preref
 
 preRef.o : preRef.cpp
-	$(CC) $(COFLAGS) preRef.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) preRef.cpp
 
 rsem-parse-alignments : parseIt.o sam/libbam.a
-	$(CC) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz -lpthread 
+	$(CC) $(CFLAGS) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz -lpthread
 
 parseIt.o : parseIt.cpp
-	$(CC) -Wall -O2 -c -I. parseIt.cpp
+	$(CC) $(CFLAGS) -O2 -c parseIt.cpp
 
 rsem-build-read-index : buildReadIndex.cpp
-	$(CC) -O3 buildReadIndex.cpp -o rsem-build-read-index
+	$(CC) $(CFLAGS) -O3 buildReadIndex.cpp -o rsem-build-read-index
 
 rsem-run-em : EM.o sam/libbam.a
-	$(CC) -o rsem-run-em EM.o sam/libbam.a -lz -lpthread
+	$(CC) $(CFLAGS) -o rsem-run-em EM.o sam/libbam.a -lz -lpthread
 
 EM.o : EM.cpp
-	$(CC) $(COFLAGS) EM.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) EM.cpp
 
 rsem-tbam2gbam : tbam2gbam.cpp sam/libbam.a
-	$(CC) -O3 -Wall tbam2gbam.cpp sam/libbam.a -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 tbam2gbam.cpp sam/libbam.a -lz -lpthread -o $@
 
 rsem-bam2wig : wiggle.o sam/libbam.a bam2wig.cpp
-	$(CC) -O3 -Wall bam2wig.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 bam2wig.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
 
 rsem-bam2readdepth : wiggle.o sam/libbam.a bam2readdepth.cpp
-	$(CC) -O3 -Wall bam2readdepth.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 bam2readdepth.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
 
 wiggle.o: wiggle.cpp
-	$(CC) $(COFLAGS) wiggle.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) wiggle.cpp
 
 rsem-simulate-reads : simulation.o
-	$(CC) -o rsem-simulate-reads simulation.o
+	$(CC) $(CFLAGS) -o rsem-simulate-reads simulation.o
 
 simulation.o : simulation.cpp
-	$(CC) $(COFLAGS) simulation.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) simulation.cpp
 
 rsem-run-gibbs : Gibbs.o
-	$(CC) -o rsem-run-gibbs Gibbs.o -lpthread
+	$(CC) $(CFLAGS) -o rsem-run-gibbs Gibbs.o -lpthread
 
 Gibbs.o : Gibbs.cpp
-	$(CC) $(COFLAGS) Gibbs.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) Gibbs.cpp
 
 rsem-calculate-credibility-intervals : calcCI.o
-	$(CC) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
+	$(CC) $(CFLAGS) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
 
 calcCI.o : calcCI.cpp
-	$(CC) $(COFLAGS) calcCI.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) calcCI.cpp
 
 rsem-get-unique : getUnique.cpp sam/libbam.a
-	$(CC) -O3 -Wall getUnique.cpp sam/libbam.a -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 getUnique.cpp sam/libbam.a -lz -lpthread -o $@
 
 rsem-sam-validator : samValidator.cpp sam/libbam.a
-	$(CC) -O3 -Wall samValidator.cpp sam/libbam.a -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 samValidator.cpp sam/libbam.a -lz -lpthread -o $@
 
 rsem-scan-for-paired-end-reads : scanForPairedEndReads.cpp sam/libbam.a
-	$(CC) -O3 -Wall scanForPairedEndReads.cpp sam/libbam.a -lz -lpthread -o $@
+	$(CC) $(CFLAGS) -O3 scanForPairedEndReads.cpp sam/libbam.a -lz -lpthread -o $@
 
 ebseq :
 	cd EBSeq ; ${MAKE} all

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,32 @@ all : $(PROGRAMS)
 sam/libbam.a :
 	cd sam ; ${MAKE} all
 
+ebseq :
+	cd EBSeq ; ${MAKE} all
+
+
+calcCI.o : calcCI.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) calcCI.cpp
+
+EM.o : EM.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) EM.cpp
+
+Gibbs.o : Gibbs.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) Gibbs.cpp
+
+preRef.o : preRef.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) preRef.cpp
+
+parseIt.o : parseIt.cpp
+	$(CC) $(CFLAGS) -O2 -c parseIt.cpp
+
+simulation.o : simulation.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) simulation.cpp
+
+wiggle.o: wiggle.cpp
+	$(CC) $(CFLAGS) $(COFLAGS) wiggle.cpp
+
+
 rsem-extract-reference-transcripts : extractRef.cpp
 	$(CC) $(CFLAGS) -O3 extractRef.cpp -o rsem-extract-reference-transcripts
 
@@ -19,23 +45,14 @@ rsem-synthesis-reference-transcripts : synthesisRef.cpp
 rsem-preref : preRef.o
 	$(CC) $(CFLAGS) preRef.o -o rsem-preref
 
-preRef.o : preRef.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) preRef.cpp
-
 rsem-parse-alignments : parseIt.o sam/libbam.a
 	$(CC) $(CFLAGS) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz -lpthread
-
-parseIt.o : parseIt.cpp
-	$(CC) $(CFLAGS) -O2 -c parseIt.cpp
 
 rsem-build-read-index : buildReadIndex.cpp
 	$(CC) $(CFLAGS) -O3 buildReadIndex.cpp -o rsem-build-read-index
 
 rsem-run-em : EM.o sam/libbam.a
 	$(CC) $(CFLAGS) -o rsem-run-em EM.o sam/libbam.a -lz -lpthread
-
-EM.o : EM.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) EM.cpp
 
 rsem-tbam2gbam : tbam2gbam.cpp sam/libbam.a
 	$(CC) $(CFLAGS) -O3 tbam2gbam.cpp sam/libbam.a -lz -lpthread -o $@
@@ -46,26 +63,14 @@ rsem-bam2wig : wiggle.o sam/libbam.a bam2wig.cpp
 rsem-bam2readdepth : wiggle.o sam/libbam.a bam2readdepth.cpp
 	$(CC) $(CFLAGS) -O3 bam2readdepth.cpp wiggle.o sam/libbam.a -lz -lpthread -o $@
 
-wiggle.o: wiggle.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) wiggle.cpp
-
 rsem-simulate-reads : simulation.o
 	$(CC) $(CFLAGS) -o rsem-simulate-reads simulation.o
-
-simulation.o : simulation.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) simulation.cpp
 
 rsem-run-gibbs : Gibbs.o
 	$(CC) $(CFLAGS) -o rsem-run-gibbs Gibbs.o -lpthread
 
-Gibbs.o : Gibbs.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) Gibbs.cpp
-
 rsem-calculate-credibility-intervals : calcCI.o
 	$(CC) $(CFLAGS) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
-
-calcCI.o : calcCI.cpp
-	$(CC) $(CFLAGS) $(COFLAGS) calcCI.cpp
 
 rsem-get-unique : getUnique.cpp sam/libbam.a
 	$(CC) $(CFLAGS) -O3 getUnique.cpp sam/libbam.a -lz -lpthread -o $@
@@ -75,9 +80,6 @@ rsem-sam-validator : samValidator.cpp sam/libbam.a
 
 rsem-scan-for-paired-end-reads : scanForPairedEndReads.cpp sam/libbam.a
 	$(CC) $(CFLAGS) -O3 scanForPairedEndReads.cpp sam/libbam.a -lz -lpthread -o $@
-
-ebseq :
-	cd EBSeq ; ${MAKE} all
 
 clean :
 	rm -f *.o *~ $(PROGRAMS)


### PR DESCRIPTION
This patch set simplifies the Makefile.

This makes it much easier for package maintainers to ignore the bundled version of Samtools and Boost, and to build RSEM against system libraries / include headers.  A packager would only have to provide a different value for `CFLAGS` with the appropriate include path and library path.

(I'm packaging RSEM for GNU Guix and I would like to avoid the bundled Boost includes and the bundled version of Samtools.)