### PR TITLE
fix a bug in generating normalized matrix

### DIFF
--- a/EBSeq/rsem-for-ebseq-find-DE
+++ b/EBSeq/rsem-for-ebseq-find-DE
@@ -10,7 +10,10 @@ path <- argv[1]
 ngvector_file <- argv[2]
 data_matrix_file <- argv[3]
 output_file <- argv[4]
-norm_out_file <- paste0("norm_", data_matrix_file)
+tmp_split <- strsplit(data_matrix_file, split="\\.")[[1]]
+tmp_prefix <- paste(tmp_split[1:(length(tmp_split)-1)], collapse=".")
+tmp_prefix2 <- paste0(tmp_prefix, ".norm")
+norm_out_file <- paste(tmp_prefix2, tmp_split[length(tmp_split)], sep=".")
 
 nc <- length(argv) - 4;
 num_reps <- as.numeric(argv[5:(5+nc-1)])


### PR DESCRIPTION
The bug will cause error when name of the input matrix contains path