### PR TITLE
Convert RSEM to use the HTSlib API instead of the legacy samtools API

### DIFF
--- a/BamConverter.h
+++ b/BamConverter.h
@@ -51,7 +51,8 @@ BamConverter::BamConverter(const char* inpF, const char* outF, const char* chr_l
 
 	transcripts.buildMappings(in->header->n_targets, in->header->target_name);
 
-	bam_hdr_t *out_header = sam_header_read2(chr_list);
+	std::string text = fai_headers(chr_list);
+	bam_hdr_t *out_header = sam_hdr_parse(text.length(), text.c_str());
 
 	refmap.clear();
 	for (int i = 0; i < out_header->n_targets; ++i) {

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ PROGRAMS = rsem-extract-reference-transcripts rsem-synthesis-reference-transcrip
 
 all : $(PROGRAMS)
 
-$(SAMTOOLS)/libbam.a : $(SAMTOOLS)/$(HTSLIB)/libhts.a
-
 $(SAMTOOLS)/$(HTSLIB)/libhts.a : 
 	cd $(SAMTOOLS) ; ${MAKE} all
 
@@ -56,15 +54,15 @@ PairedEndHit.h : SingleHit.h
 
 HitContainer.h : GroupInfo.h
 
-sam_utils.h : $(SAMTOOLS)/bam.h Transcript.h Transcripts.h
+sam_utils.h : Transcript.h Transcripts.h
 
-SamParser.h : $(SAMTOOLS)/sam.h $(SAMTOOLS)/bam.h sam_utils.h utils.h my_assert.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Transcripts.h
+SamParser.h : sam_utils.h utils.h my_assert.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Transcripts.h
 
 
 rsem-parse-alignments : parseIt.o $(SAMLIBS)
 	$(CC) -o rsem-parse-alignments parseIt.o $(SAMLIBS) -lz -lpthread 
 
-parseIt.o : $(SAMTOOLS)/sam.h $(SAMTOOLS)/bam.h sam_utils.h utils.h my_assert.h GroupInfo.h Transcripts.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h HitContainer.h SamParser.h parseIt.cpp
+parseIt.o : sam_utils.h utils.h my_assert.h GroupInfo.h Transcripts.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h HitContainer.h SamParser.h parseIt.cpp
 	$(CC) -Wall -O2 -c -I. $(SAMFLAGS) parseIt.cpp
 
 
@@ -88,7 +86,7 @@ HitWrapper.h : HitContainer.h
 
 
 
-BamWriter.h : $(SAMTOOLS)/sam.h $(SAMTOOLS)/bam.h sam_utils.h utils.h my_assert.h SingleHit.h PairedEndHit.h HitWrapper.h Transcript.h Transcripts.h
+BamWriter.h : sam_utils.h utils.h my_assert.h SingleHit.h PairedEndHit.h HitWrapper.h Transcript.h Transcripts.h
 
 sampling.h : boost/random.hpp
 
@@ -97,17 +95,15 @@ WriteResults.h : utils.h my_assert.h GroupInfo.h Transcript.h Transcripts.h RefS
 rsem-run-em : EM.o $(SAMLIBS)
 	$(CC) -o rsem-run-em EM.o $(SAMLIBS) -lz -lpthread
 
-EM.o : utils.h my_assert.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h Refs.h GroupInfo.h HitContainer.h ReadIndex.h ReadReader.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h ModelParams.h RefSeq.h RefSeqPolicy.h PolyARules.h Profile.h NoiseProfile.h Transcript.h Transcripts.h HitWrapper.h BamWriter.h $(SAMTOOLS)/bam.h $(SAMTOOLS)/sam.h simul.h sam_utils.h sampling.h boost/random.hpp WriteResults.h EM.cpp
+EM.o : utils.h my_assert.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h Refs.h GroupInfo.h HitContainer.h ReadIndex.h ReadReader.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h ModelParams.h RefSeq.h RefSeqPolicy.h PolyARules.h Profile.h NoiseProfile.h Transcript.h Transcripts.h HitWrapper.h BamWriter.h simul.h sam_utils.h sampling.h boost/random.hpp WriteResults.h EM.cpp
 	$(CC) $(COFLAGS) $(SAMFLAGS) EM.cpp
 
-bc_aux.h : $(SAMTOOLS)/bam.h
+BamConverter.h : sam_utils.h utils.h my_assert.h bc_aux.h Transcript.h Transcripts.h
 
-BamConverter.h : $(SAMTOOLS)/bam.h $(SAMTOOLS)/sam.h sam_utils.h utils.h my_assert.h bc_aux.h Transcript.h Transcripts.h
-
-rsem-tbam2gbam : utils.h Transcripts.h Transcript.h BamConverter.h $(SAMTOOLS)/sam.h $(SAMTOOLS)/bam.h sam_utils.h my_assert.h bc_aux.h tbam2gbam.cpp $(SAMLIBS)
+rsem-tbam2gbam : utils.h Transcripts.h Transcript.h BamConverter.h sam_utils.h my_assert.h bc_aux.h tbam2gbam.cpp $(SAMLIBS)
 	$(CC) $(LFLAGS) $(SAMFLAGS) tbam2gbam.cpp $(SAMLIBS) -lz -lpthread -o $@
 
-wiggle.o: $(SAMTOOLS)/bam.h $(SAMTOOLS)/sam.h sam_utils.h utils.h my_assert.h wiggle.h wiggle.cpp
+wiggle.o: sam_utils.h utils.h my_assert.h wiggle.h wiggle.cpp
 	$(CC) $(COFLAGS) $(SAMFLAGS) wiggle.cpp
 
 rsem-bam2wig : utils.h my_assert.h wiggle.h wiggle.o $(SAMLIBS) bam2wig.cpp
@@ -139,13 +135,13 @@ rsem-calculate-credibility-intervals : calcCI.o
 calcCI.o : utils.h my_assert.h boost/random.hpp sampling.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h RefSeq.h RefSeqPolicy.h PolyARules.h Refs.h GroupInfo.h WriteResults.h Buffer.h calcCI.cpp
 	$(CC) $(COFLAGS) calcCI.cpp
 
-rsem-get-unique : $(SAMTOOLS)/bam.h $(SAMTOOLS)/sam.h sam_utils.h utils.h getUnique.cpp $(SAMLIBS)
+rsem-get-unique : sam_utils.h utils.h getUnique.cpp $(SAMLIBS)
 	$(CC) $(LFLAGS) $(SAMFLAGS) getUnique.cpp $(SAMLIBS) -lz -lpthread -o $@
 
-rsem-sam-validator : $(SAMTOOLS)/bam.h $(SAMTOOLS)/sam.h sam_utils.h utils.h my_assert.h samValidator.cpp $(SAMLIBS)
+rsem-sam-validator : sam_utils.h utils.h my_assert.h samValidator.cpp $(SAMLIBS)
 	$(CC) $(LFLAGS) $(SAMFLAGS) samValidator.cpp $(SAMLIBS) -lz -lpthread -o $@
 
-rsem-scan-for-paired-end-reads : $(SAMTOOLS)/bam.h $(SAMTOOLS)/sam.h sam_utils.h utils.h my_assert.h scanForPairedEndReads.cpp $(SAMLIBS)
+rsem-scan-for-paired-end-reads : sam_utils.h utils.h my_assert.h scanForPairedEndReads.cpp $(SAMLIBS)
 	$(CC) $(LFLAGS) $(SAMFLAGS) scanForPairedEndReads.cpp $(SAMLIBS) -lz -lpthread -o $@
 
 ebseq :

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ LFLAGS = -Wall -O3 -I.
 
 SAMTOOLS = samtools-1.3
 HTSLIB = htslib-1.3
-SAMFLAGS = -I$(SAMTOOLS) -I$(SAMTOOLS)/$(HTSLIB)
-SAMLIBS = $(SAMTOOLS)/libbam.a $(SAMTOOLS)/$(HTSLIB)/libhts.a
+SAMFLAGS = -I$(SAMTOOLS)/$(HTSLIB)
+SAMLIBS = $(SAMTOOLS)/$(HTSLIB)/libhts.a
 PROGRAMS = rsem-extract-reference-transcripts rsem-synthesis-reference-transcripts rsem-preref rsem-parse-alignments rsem-build-read-index rsem-run-em rsem-tbam2gbam rsem-run-gibbs rsem-calculate-credibility-intervals rsem-simulate-reads rsem-bam2wig rsem-get-unique rsem-bam2readdepth rsem-sam-validator rsem-scan-for-paired-end-reads
 
 

--- a/bc_aux.h
+++ b/bc_aux.h
@@ -4,7 +4,7 @@
 #include<map>
 
 #include <stdint.h>
-#include "bam.h"
+#include "htslib/sam.h"
 
 struct SingleEndT {
 	bam1_t *b;

--- a/sam_utils.h
+++ b/sam_utils.h
@@ -62,6 +62,22 @@ inline void expand_data_size(bam1_t *b) {
   }
 }
 
+inline std::string fai_headers(const char *fname) {
+  FILE *fi = fopen(fname, "r");
+  if (fi == NULL) return "";
+
+  std::string s;
+  char line[2048];
+  while (fgets(line, sizeof line, fi)) {
+    const char *name = strtok(line, "\t");
+    const char *len = strtok(NULL, "\t");
+    s.append("@SQ\tSN:").append(name).append("\tLN:").append(len).append("\n");
+  }
+
+  fclose(fi);
+  return s;
+}
+
 /******************************************************/
 
 // These functions are specially designed for RSEM

--- a/sam_utils.h
+++ b/sam_utils.h
@@ -7,7 +7,7 @@
 #include<string>
 #include<stdint.h>
 
-#include "bam.h"
+#include "htslib/sam.h"
 
 #include "Transcript.h"
 #include "Transcripts.h"
@@ -55,7 +55,7 @@ void append_header_text(bam_hdr_t *header, const char* text, int len)
 }
 
 inline void expand_data_size(bam1_t *b) {
-  if (b->m_data < b->data_len) {
+  if (b->m_data < b->l_data) {
     b->m_data = b->l_data;
     kroundup32(b->m_data);
     b->data = (uint8_t*)realloc(b->data, b->m_data);


### PR DESCRIPTION
This pull request converts the RSEM source code to use HTSlib for its BAM-reading needs rather than the old samtools 0.1.x API.  Since the old API is unmaintained (and has been for several years), we would recommend converting to the new API wholesale rather than continuing with the old API (cf @outpaddling's samtools/samtools#531).

This compiles against just htslib, but I have not tested it or even tried to run it.  So there would need to be a bedding-in period, especially of the fresh code in 5852e1ef73648606e02eb92c0bc49c0ccab121b4.

I realise you have some local changes in _samtools-1.3/bam_sort.c_ (ccec130769207255411170f316587b5160ff6ae0).  We are still considering how best to deal with your samtools/samtools#520; most likely mainline `samtools sort -n` will gain an ability to keep mates together.