### PR TITLE
Standardize compiler variables and allow override, add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-CC = g++ -std=gnu++98
+CXX ?= g++
 CFLAGS = -Wall -c -I.
-COFLAGS = -Wall -O3 -ffast-math -c -I.
-LFLAGS = -Wall -O3 -I.
+CXXFLAGS ?= -Wall -O3
+CXXFLAGS += -I.
+COFLAGS = ${CXXFLAGS} -ffast-math -c
+INSTALL ?=	install
+STRIP ?=	strip
+MKDIR ?=	mkdir
+PREFIX ?=	bin
+DESTDIR ?=	dest
+SITE_PERL ?=	${PREFIX}/share/perl5
 
 SAMTOOLS = samtools-1.3
 HTSLIB = htslib-1.3
@@ -11,6 +18,7 @@ SAMLIBS = $(SAMTOOLS)/$(HTSLIB)/libhts.a
 
 PROGRAMS = rsem-extract-reference-transcripts rsem-synthesis-reference-transcripts rsem-preref rsem-parse-alignments rsem-build-read-index rsem-run-em rsem-tbam2gbam rsem-run-gibbs rsem-calculate-credibility-intervals rsem-simulate-reads rsem-bam2wig rsem-get-unique rsem-bam2readdepth rsem-sam-validator rsem-scan-for-paired-end-reads
 
+SCRIPTS = convert-sam-for-rsem extract-transcript-to-gene-map-from-trinity rsem-calculate-expression rsem-control-fdr rsem-gen-transcript-plots rsem-generate-data-matrix rsem-generate-ngvector rsem-gff3-to-gtf rsem-plot-model rsem-plot-transcript-wiggles rsem-prepare-reference rsem-refseq-extract-primary-assembly rsem-run-ebseq
 
 .PHONY : all ebseq clean
 
@@ -24,10 +32,10 @@ Transcript.h : utils.h
 Transcripts.h : utils.h my_assert.h Transcript.h
 
 rsem-extract-reference-transcripts : utils.h my_assert.h GTFItem.h Transcript.h Transcripts.h extractRef.cpp
-	$(CC) $(LFLAGS) extractRef.cpp -o rsem-extract-reference-transcripts
+	$(CXX) $(CXXFLAGS) extractRef.cpp -o rsem-extract-reference-transcripts
 
 rsem-synthesis-reference-transcripts : utils.h my_assert.h Transcript.h Transcripts.h synthesisRef.cpp
-	$(CC) $(LFLAGS) synthesisRef.cpp -o rsem-synthesis-reference-transcripts
+	$(CXX) $(CXXFLAGS) synthesisRef.cpp -o rsem-synthesis-reference-transcripts
 
 BowtieRefSeqPolicy.h : RefSeqPolicy.h
 
@@ -37,10 +45,10 @@ Refs.h : utils.h RefSeq.h RefSeqPolicy.h PolyARules.h
 
 
 rsem-preref : preRef.o
-	$(CC) preRef.o -o rsem-preref
+	$(CXX) preRef.o -o rsem-preref
 
 preRef.o : utils.h RefSeq.h Refs.h PolyARules.h RefSeqPolicy.h AlignerRefSeqPolicy.h preRef.cpp
-	$(CC) $(COFLAGS) preRef.cpp
+	$(CXX) $(COFLAGS) preRef.cpp
 
 
 SingleRead.h : Read.h
@@ -62,14 +70,14 @@ SamParser.h : $(SAMHEADERS) sam_utils.h utils.h my_assert.h SingleRead.h SingleR
 
 
 rsem-parse-alignments : parseIt.o $(SAMLIBS)
-	$(CC) -o rsem-parse-alignments parseIt.o $(SAMLIBS) -lz -lpthread 
+	$(CXX) -o rsem-parse-alignments parseIt.o $(SAMLIBS) -lz -lpthread 
 
 parseIt.o : $(SAMHEADERS) sam_utils.h utils.h my_assert.h GroupInfo.h Transcripts.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h HitContainer.h SamParser.h parseIt.cpp
-	$(CC) -Wall -O2 -c -I. $(SAMFLAGS) parseIt.cpp
+	$(CXX) -Wall -O2 -c -I. $(SAMFLAGS) parseIt.cpp
 
 
 rsem-build-read-index : utils.h buildReadIndex.cpp
-	$(CC) $(LFLAGS) buildReadIndex.cpp -o rsem-build-read-index
+	$(CXX) $(CXXFLAGS) buildReadIndex.cpp -o rsem-build-read-index
 
 
 simul.h : boost/random.hpp
@@ -95,61 +103,72 @@ sampling.h : boost/random.hpp
 WriteResults.h : utils.h my_assert.h GroupInfo.h Transcript.h Transcripts.h RefSeq.h Refs.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h
 
 rsem-run-em : EM.o $(SAMLIBS)
-	$(CC) -o rsem-run-em EM.o $(SAMLIBS) -lz -lpthread
+	$(CXX) -o rsem-run-em EM.o $(SAMLIBS) -lz -lpthread
 
 EM.o : $(SAMHEADERS) utils.h my_assert.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h Refs.h GroupInfo.h HitContainer.h ReadIndex.h ReadReader.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h ModelParams.h RefSeq.h RefSeqPolicy.h PolyARules.h Profile.h NoiseProfile.h Transcript.h Transcripts.h HitWrapper.h BamWriter.h simul.h sam_utils.h sampling.h boost/random.hpp WriteResults.h EM.cpp
-	$(CC) $(COFLAGS) $(SAMFLAGS) EM.cpp
+	$(CXX) $(COFLAGS) $(SAMFLAGS) EM.cpp
 
 bc_aux.h : $(SAMHEADERS)
 
 BamConverter.h : $(SAMHEADERS) sam_utils.h utils.h my_assert.h bc_aux.h Transcript.h Transcripts.h
 
 rsem-tbam2gbam : $(SAMHEADERS) utils.h Transcripts.h Transcript.h BamConverter.h sam_utils.h my_assert.h bc_aux.h tbam2gbam.cpp $(SAMLIBS)
-	$(CC) $(LFLAGS) $(SAMFLAGS) tbam2gbam.cpp $(SAMLIBS) -lz -lpthread -o $@
+	$(CXX) $(CXXFLAGS) $(SAMFLAGS) tbam2gbam.cpp $(SAMLIBS) -lz -lpthread -o $@
 
 wiggle.o: $(SAMHEADERS) sam_utils.h utils.h my_assert.h wiggle.h wiggle.cpp
-	$(CC) $(COFLAGS) $(SAMFLAGS) wiggle.cpp
+	$(CXX) $(COFLAGS) $(SAMFLAGS) wiggle.cpp
 
 rsem-bam2wig : utils.h my_assert.h wiggle.h wiggle.o $(SAMLIBS) bam2wig.cpp
-	$(CC) $(LFLAGS) bam2wig.cpp wiggle.o $(SAMLIBS) -lz -lpthread -o $@
+	$(CXX) $(CXXFLAGS) bam2wig.cpp wiggle.o $(SAMLIBS) -lz -lpthread -o $@
 
 rsem-bam2readdepth : utils.h my_assert.h wiggle.h wiggle.o $(SAMLIBS) bam2readdepth.cpp
-	$(CC) $(LFLAGS) bam2readdepth.cpp wiggle.o $(SAMLIBS) -lz -lpthread -o $@
+	$(CXX) $(CXXFLAGS) bam2readdepth.cpp wiggle.o $(SAMLIBS) -lz -lpthread -o $@
 
 
 rsem-simulate-reads : simulation.o
-	$(CC) -o rsem-simulate-reads simulation.o
+	$(CXX) -o rsem-simulate-reads simulation.o
 
 simulation.o : utils.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h Refs.h RefSeq.h GroupInfo.h Transcript.h Transcripts.h Orientation.h LenDist.h RSPD.h QualDist.h QProfile.h NoiseQProfile.h Profile.h NoiseProfile.h simul.h boost/random.hpp WriteResults.h simulation.cpp
-	$(CC) $(COFLAGS) simulation.cpp
+	$(CXX) $(COFLAGS) simulation.cpp
 
 rsem-run-gibbs : Gibbs.o
-	$(CC) -o rsem-run-gibbs Gibbs.o -lpthread
+	$(CXX) -o rsem-run-gibbs Gibbs.o -lpthread
 
 #some header files are omitted
 Gibbs.o : utils.h my_assert.h boost/random.hpp sampling.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h RefSeq.h RefSeqPolicy.h PolyARules.h Refs.h GroupInfo.h WriteResults.h Gibbs.cpp 
-	$(CC) $(COFLAGS) Gibbs.cpp
+	$(CXX) $(COFLAGS) Gibbs.cpp
 
 Buffer.h : my_assert.h
 
 rsem-calculate-credibility-intervals : calcCI.o
-	$(CC) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
+	$(CXX) -o rsem-calculate-credibility-intervals calcCI.o -lpthread
 
 #some header files are omitted
 calcCI.o : utils.h my_assert.h boost/random.hpp sampling.h Model.h SingleModel.h SingleQModel.h PairedEndModel.h PairedEndQModel.h RefSeq.h RefSeqPolicy.h PolyARules.h Refs.h GroupInfo.h WriteResults.h Buffer.h calcCI.cpp
-	$(CC) $(COFLAGS) calcCI.cpp
+	$(CXX) $(COFLAGS) calcCI.cpp
 
 rsem-get-unique : $(SAMHEADERS) sam_utils.h utils.h getUnique.cpp $(SAMLIBS)
-	$(CC) $(LFLAGS) $(SAMFLAGS) getUnique.cpp $(SAMLIBS) -lz -lpthread -o $@
+	$(CXX) $(CXXFLAGS) $(SAMFLAGS) getUnique.cpp $(SAMLIBS) -lz -lpthread -o $@
 
 rsem-sam-validator : $(SAMHEADERS) sam_utils.h utils.h my_assert.h samValidator.cpp $(SAMLIBS)
-	$(CC) $(LFLAGS) $(SAMFLAGS) samValidator.cpp $(SAMLIBS) -lz -lpthread -o $@
+	$(CXX) $(CXXFLAGS) $(SAMFLAGS) samValidator.cpp $(SAMLIBS) -lz -lpthread -o $@
 
 rsem-scan-for-paired-end-reads : $(SAMHEADERS) sam_utils.h utils.h my_assert.h scanForPairedEndReads.cpp $(SAMLIBS)
-	$(CC) $(LFLAGS) $(SAMFLAGS) scanForPairedEndReads.cpp $(SAMLIBS) -lz -lpthread -o $@
+	$(CXX) $(CXXFLAGS) $(SAMFLAGS) scanForPairedEndReads.cpp $(SAMLIBS) -lz -lpthread -o $@
 
 ebseq :
 	cd EBSeq ; ${MAKE} all
+
+install : ${PROGRAMS}
+	for p in ${PROGRAMS}; do \
+		${INSTALL} -c $${p} ${DESTDIR}${PREFIX}/bin; \
+		${STRIP} ${DESTDIR}${PREFIX}/bin/$${p}; \
+	done
+	for s in ${SCRIPTS}; do \
+		${INSTALL} -c $${s} ${DESTDIR}${PREFIX}/bin; \
+	done
+	${MKDIR} -p ${DESTDIR}${SITE_PERL}/rsem
+	${INSTALL} -c rsem_perl_utils.pm ${DESTDIR}${SITE_PERL}/rsem
 
 clean :
 	rm -f *.o *~ $(PROGRAMS)

--- a/samtools-1.3/Makefile
+++ b/samtools-1.3/Makefile
@@ -21,9 +21,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-CC       = gcc
+CC       ?= gcc
 CPPFLAGS =
-CFLAGS   = -g -Wall -O2
+CFLAGS   ?= -g -Wall -O2
 LDFLAGS  =
 LIBS     =
 

--- a/samtools-1.3/htslib-1.3/Makefile
+++ b/samtools-1.3/htslib-1.3/Makefile
@@ -22,13 +22,13 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-CC     = gcc
+CC     ?= gcc
 AR     = ar
 RANLIB = ranlib
 
 CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
-CFLAGS   = -g -Wall -O2
+CFLAGS   ?= -g -Wall -O2
 EXTRA_CFLAGS_PIC = -fpic
 LDFLAGS  =
 LIBS     =


### PR DESCRIPTION
These changes standardize the names of compiler variables like CXX and CXXFLAGS and allow them to be overridden by the environment.

Also added a basic install target to the master Makefile.

These changes will aid package managers (Debian packages, FreeBSD ports, MacPorts, etc.), which set standard compiler variables and utilize an install target if available.

The default behavior of the Makefile, when used outside a package manager, should be the same as before.

Some minor patching will still be needed, such as setting the Perl lib path for scripts that use the Perl module.  For now I've left this to the package maintainer.