### PR TITLE
Adjust POD to produce better manual pages

### DIFF
--- a/convert-sam-for-rsem
+++ b/convert-sam-for-rsem
@@ -56,11 +56,7 @@ __END__
 
 =head1 NAME
 
-convert-sam-for-rsem
-
-=head1 PURPOSE
-
-Make a RSEM compatible BAM file.
+convert-sam-for-rsem - Make a RSEM compatible BAM file.
 
 =head1 SYNOPSIS
 

--- a/rsem-calculate-expression
+++ b/rsem-calculate-expression
@@ -774,11 +774,7 @@ __END__
 
 =head1 NAME
 
-rsem-calculate-expression
-
-=head1 PURPOSE
-
-Estimate gene and isoform expression from RNA-Seq data.
+rsem-calculate-expression - Estimate gene and isoform expression from RNA-Seq data.
 
 =head1 SYNOPSIS
 

--- a/rsem-control-fdr
+++ b/rsem-control-fdr
@@ -62,11 +62,7 @@ __END__
 
 =head1 NAME
 
-rsem-control-fdr
-
-=head1 PURPOSE
-
-Filter EBSeq output for statistical significance.
+rsem-control-fdr - Filter EBSeq output for statistical significance.
 
 =head1 SYNOPSIS
 

--- a/rsem-generate-ngvector
+++ b/rsem-generate-ngvector
@@ -33,11 +33,7 @@ __END__
 
 =head1 NAME
 
-rsem-generate-ngvector
-
-=head1 PURPOSE
-
-Create Ng vector for EBSeq based only on transcript sequences.
+rsem-generate-ngvector - Create Ng vector for EBSeq based only on transcript sequences.
 
 =head1 SYNOPSIS
 

--- a/rsem-plot-transcript-wiggles
+++ b/rsem-plot-transcript-wiggles
@@ -81,11 +81,7 @@ __END__
 
 =head1 NAME
 
-rsem-plot-transcript-wiggles
-
-=head1 PURPOSE
-
-Generate PDF wiggle plots from transcript or gene ids
+rsem-plot-transcript-wiggles - Generate PDF wiggle plots from transcript or gene ids
 
 =head1 SYNOPSIS
 

--- a/rsem-prepare-reference
+++ b/rsem-prepare-reference
@@ -219,11 +219,7 @@ __END__
 
 =head1 NAME
 
-rsem-prepare-reference
-
-=head1 PURPOSE
-
-Prepare transcript references for RSEM and optionally build BOWTIE/BOWTIE2/STAR indices.
+rsem-prepare-reference - Prepare transcript references for RSEM and optionally build BOWTIE/BOWTIE2/STAR indices.
 
 =head1 SYNOPSIS
 

--- a/rsem-run-ebseq
+++ b/rsem-run-ebseq
@@ -38,11 +38,7 @@ __END__
 
 =head1 NAME
 
-rsem-run-ebseq
-
-=head1 PURPOSE
-
-Wrapper for EBSeq to perform differential expression analysis.
+rsem-run-ebseq - Wrapper for EBSeq to perform differential expression analysis.
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
From Pod::Checker:

The NAME section ("=head1 NAME") should consist of a single paragraph with the
script/module name, followed by a dash `-' and a very short description of what
the thing is good for.