### PR TITLE
Fix in rsem-gff3-to-gtf for Python3 compatibility

### DIFF
--- a/rsem-gff3-to-gtf
+++ b/rsem-gff3-to-gtf
@@ -160,6 +160,9 @@ class Transcript:
 		self.index += 1
 		return interval
 
+	def __next__(self):
+		return self.next()
+
 
 def getTranscript(tid, feature):
 	assert tid != None


### PR DESCRIPTION
rsem-gff3-to-gtf was failing for me because I use Python 3 as my default python

Python 3 expects iterators to have a __next__() method instead of just next()