### PR TITLE
Fix assertion error for arrays with lots of zeros.

### DIFF
--- a/simul.h
+++ b/simul.h
@@ -18,6 +18,10 @@ public:
 	  int l, r, mid;
 	  double prb = random() * arr[len - 1];
 
+    // if the final value is zero, pick a random index from the array.
+    if (arr[len - 1] == 0.0) {
+      return random() * (len - 1);
+    }
 
 	  l = 0; r = len - 1;
 	  while (l <= r) {
@@ -40,4 +44,3 @@ private:
 };
 
 #endif /* SIMUL_H_ */
-


### PR DESCRIPTION
The logic for sampling arrays fails when most of the array is zero.
We fix this by sampling uniformly from the indices into the array,
as suggested by the comment in simul.h.