### PR TITLE
C++11 fixes for clang

### DIFF
--- a/PairedEndHit.h
+++ b/PairedEndHit.h
@@ -26,7 +26,7 @@ private:
 
 bool PairedEndHit::read(std::istream& in) {
 	conprb = 0.0;
-    return (in>>sid>>pos>>insertL);
+    return static_cast<bool>(in>>sid>>pos>>insertL);
 }
 
 void PairedEndHit::write(std::ostream& out) {

--- a/SingleHit.h
+++ b/SingleHit.h
@@ -43,7 +43,7 @@ protected:
 
 bool SingleHit::read(std::istream& in) {
 	conprb = 0.0;
-	return (in>>sid>>pos);
+	return static_cast<bool>(in>>sid>>pos);
 }
 
 void SingleHit::write(std::ostream& out) {

--- a/buildReadIndex.cpp
+++ b/buildReadIndex.cpp
@@ -37,15 +37,15 @@ void buildIndex(char* readF, int gap, bool hasQ) {
 		streampos pos = fin.tellg();
 		success = true;
 
-		success = (getline(fin, line));
+		success = static_cast<bool>(getline(fin, line));
 		if (!success) continue;
-		success = (getline(fin, line));
+		success = static_cast<bool>(getline(fin, line));
 		if (!success) continue;
 
 		if (hasQ) {
-			success = (getline(fin, line));
+			success = static_cast<bool>(getline(fin, line));
 			if (!success) continue;
-			success = (getline(fin, line));
+			success = static_cast<bool>(getline(fin, line));
 			if (!success) continue;
 		}
 


### PR DESCRIPTION
std::basic_ios needs an explicit conversion to bool from C++11 onwards.
gcc has a bug that ignores this, but clang catches this as an error.

http://en.cppreference.com/w/cpp/io/basic_ios/operator_bool