### PR TITLE
Make the code compile with C++17

### DIFF
--- a/PolyARules.h
+++ b/PolyARules.h
@@ -47,7 +47,7 @@ public:
 		case 1 : return 0;
 		case 2 : iter = exceptionList.find(transcript_id);
 				 return (iter == exceptionList.end() ? polyALen : 0);
-		default : assert(false);
+                default : abort();
 		}
 	}
 

--- a/boost/math/special_functions/detail/lanczos_sse2.hpp
+++ b/boost/math/special_functions/detail/lanczos_sse2.hpp
@@ -51,11 +51,11 @@ inline double lanczos13m53::lanczos_sum<double>(const double& x)
       static_cast<double>(23531376880.41075968857200767445163675473L),
       static_cast<double>(0u)
    };
-   register __m128d vx = _mm_load1_pd(&x);
-   register __m128d sum_even = _mm_load_pd(coeff);
-   register __m128d sum_odd = _mm_load_pd(coeff+2);
-   register __m128d nc_odd, nc_even;
-   register __m128d vx2 = _mm_mul_pd(vx, vx);
+   __m128d vx = _mm_load1_pd(&x);
+   __m128d sum_even = _mm_load_pd(coeff);
+   __m128d sum_odd = _mm_load_pd(coeff+2);
+   __m128d nc_odd, nc_even;
+   __m128d vx2 = _mm_mul_pd(vx, vx);
 
    sum_even = _mm_mul_pd(sum_even, vx2);
    nc_even = _mm_load_pd(coeff + 4);
@@ -101,7 +101,7 @@ inline double lanczos13m53::lanczos_sum<double>(const double& x)
 
    double ALIGN16 t[2];
    _mm_store_pd(t, sum_even);
-   
+
    return t[0] / t[1];
 }
 
@@ -136,11 +136,11 @@ inline double lanczos13m53::lanczos_sum_expG_scaled<double>(const double& x)
          static_cast<double>(56906521.91347156388090791033559122686859L),
          static_cast<double>(0u)
    };
-   register __m128d vx = _mm_load1_pd(&x);
-   register __m128d sum_even = _mm_load_pd(coeff);
-   register __m128d sum_odd = _mm_load_pd(coeff+2);
-   register __m128d nc_odd, nc_even;
-   register __m128d vx2 = _mm_mul_pd(vx, vx);
+   __m128d vx = _mm_load1_pd(&x);
+   __m128d sum_even = _mm_load_pd(coeff);
+   __m128d sum_odd = _mm_load_pd(coeff+2);
+   __m128d nc_odd, nc_even;
+   __m128d vx2 = _mm_mul_pd(vx, vx);
 
    sum_even = _mm_mul_pd(sum_even, vx2);
    nc_even = _mm_load_pd(coeff + 4);
@@ -186,7 +186,7 @@ inline double lanczos13m53::lanczos_sum_expG_scaled<double>(const double& x)
 
    double ALIGN16 t[2];
    _mm_store_pd(t, sum_even);
-   
+
    return t[0] / t[1];
 }
 
@@ -197,8 +197,3 @@ inline double lanczos13m53::lanczos_sum_expG_scaled<double>(const double& x)
 #undef ALIGN16
 
 #endif // BOOST_MATH_SPECIAL_FUNCTIONS_LANCZOS
-
-
-
-
-

--- a/boost/random/uniform_on_sphere.hpp
+++ b/boost/random/uniform_on_sphere.hpp
@@ -34,7 +34,7 @@ namespace random {
  * numbers uniformly distributed on the unit sphere of arbitrary
  * dimension @c dim. The @c Cont template parameter must be a STL-like
  * container type with begin and end operations returning non-const
- * ForwardIterators of type @c Cont::iterator. 
+ * ForwardIterators of type @c Cont::iterator.
  */
 template<class RealType = double, class Cont = std::vector<RealType> >
 class uniform_on_sphere
@@ -170,9 +170,9 @@ public:
             sqsum += val * val;
         }
         using std::sqrt;
-        // for all i: result[i] /= sqrt(sqsum)
-        std::transform(_container.begin(), _container.end(), _container.begin(),
-                       std::bind2nd(std::divides<RealType>(), sqrt(sqsum)));
+        for (auto& it : _container) {
+          *it /= sqrt(sqsum);
+        }
         return _container;
     }
 

--- a/boost/smart_ptr/detail/shared_count.hpp
+++ b/boost/smart_ptr/detail/shared_count.hpp
@@ -31,7 +31,7 @@
 #include <boost/detail/workaround.hpp>
 // In order to avoid circular dependencies with Boost.TR1
 // we make sure that our include of <memory> doesn't try to
-// pull in the TR1 headers: that's why we use this header 
+// pull in the TR1 headers: that's why we use this header
 // rather than including <memory> directly:
 #include <boost/config/no_tr1/memory.hpp>  // std::auto_ptr
 #include <functional>       // std::less
@@ -66,7 +66,7 @@ template< class D > struct sp_inplace_tag
 #if !defined( BOOST_NO_CXX11_SMART_PTR )
 
 template< class T > class sp_reference_wrapper
-{ 
+{
 public:
 
     explicit sp_reference_wrapper( T & t): t_( boost::addressof( t ) )
@@ -320,7 +320,7 @@ public:
     // auto_ptr<Y> is special cased to provide the strong guarantee
 
     template<class Y>
-    explicit shared_count( std::auto_ptr<Y> & r ): pi_( new sp_counted_impl_p<Y>( r.get() ) )
+    explicit shared_count( std::unique_ptr<Y> & r ): pi_( new sp_counted_impl_p<Y>( r.get() ) )
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(shared_count_id)
 #endif
@@ -337,7 +337,7 @@ public:
         r.release();
     }
 
-#endif 
+#endif
 
 #if !defined( BOOST_NO_CXX11_SMART_PTR )
 

--- a/boost/smart_ptr/shared_ptr.hpp
+++ b/boost/smart_ptr/shared_ptr.hpp
@@ -22,7 +22,7 @@
 
 // In order to avoid circular dependencies with Boost.TR1
 // we make sure that our include of <memory> doesn't try to
-// pull in the TR1 headers: that's why we use this header 
+// pull in the TR1 headers: that's why we use this header
 // rather than including <memory> directly:
 #include <boost/config/no_tr1/memory.hpp>  // std::auto_ptr
 
@@ -244,10 +244,10 @@ template< class T, class R > struct sp_enable_if_auto_ptr
 {
 };
 
-template< class T, class R > struct sp_enable_if_auto_ptr< std::auto_ptr< T >, R >
+template< class T, class R > struct sp_enable_if_auto_ptr< std::unique_ptr< T >, R >
 {
     typedef R type;
-}; 
+};
 
 #endif
 
@@ -443,7 +443,7 @@ public:
 #ifndef BOOST_NO_AUTO_PTR
 
     template<class Y>
-    explicit shared_ptr( std::auto_ptr<Y> & r ): px(r.get()), pn()
+    explicit shared_ptr( std::unique_ptr<Y> & r ): px(r.get()), pn()
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -456,7 +456,7 @@ public:
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
     template<class Y>
-    shared_ptr( std::auto_ptr<Y> && r ): px(r.get()), pn()
+    shared_ptr( std::unique_ptr<Y> && r ): px(r.get()), pn()
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -522,7 +522,7 @@ public:
 #ifndef BOOST_NO_AUTO_PTR
 
     template<class Y>
-    shared_ptr & operator=( std::auto_ptr<Y> & r )
+    shared_ptr & operator=( std::unique_ptr<Y> & r )
     {
         this_type( r ).swap( *this );
         return *this;
@@ -531,9 +531,9 @@ public:
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
     template<class Y>
-    shared_ptr & operator=( std::auto_ptr<Y> && r )
+    shared_ptr & operator=( std::unique_ptr<Y> && r )
     {
-        this_type( static_cast< std::auto_ptr<Y> && >( r ) ).swap( *this );
+        this_type( static_cast< std::unique_ptr<Y> && >( r ) ).swap( *this );
         return *this;
     }
 
@@ -639,21 +639,21 @@ public:
     {
         this_type( r, p ).swap( *this );
     }
-    
+
     // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
     typename boost::detail::sp_dereference< T >::type operator* () const
     {
         BOOST_ASSERT( px != 0 );
         return *px;
     }
-    
+
     // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
-    typename boost::detail::sp_member_access< T >::type operator-> () const 
+    typename boost::detail::sp_member_access< T >::type operator-> () const
     {
         BOOST_ASSERT( px != 0 );
         return px;
     }
-    
+
     // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
     typename boost::detail::sp_array_access< T >::type operator[] ( std::ptrdiff_t i ) const
     {


### PR DESCRIPTION
We should be able to get rid of boost entirely. But in the meanwhile
this commit makes a minimal set of changes to make the code compile with C++17.