### PR TITLE
Update rsem_perl_utils.pm

### DIFF
--- a/rsem_perl_utils.pm
+++ b/rsem_perl_utils.pm
@@ -9,7 +9,7 @@ our @ISA = qw(Exporter);
 our @EXPORT = qw(runCommand);
 our @EXPORT_OK = qw(runCommand collectResults showVersionInfo getSAMTOOLS hasPolyA);
 
-my $version = "RSEM v1.3.1"; # Update version info here
+my $version = "RSEM v1.3.3"; # Update version info here
 my $samtools = "samtools-1.3"; # If update to another version of SAMtools, need to change this
 
 # command, {err_msg}


### PR DESCRIPTION
Hi,
I have updated the `rsem_perl_utils.pm` to reflect correct version for command `rsem-calculate-expression --version`. Currently, it is outputting the previous version.

Thanks,
Khushbu