### PR TITLE
Add limitGenomeGenerateRAM and genomeSAindexNbases to STAR build via rsem-prepare-reference

### DIFF
--- a/rsem-prepare-reference
+++ b/rsem-prepare-reference
@@ -43,6 +43,7 @@ my $bowtie2_path = "";
 my $star = 0;
 my $star_path = '';
 my $star_sjdboverhang = 100;
+my $star_ramlimit = ''; ## for STAR, the limit of RAM to use for building genome indices, in bytes. Default is 31GB, set below which is enough for most genomes.
 
 my $hisat2_hca = 0;
 my $hisat2_path = '';
@@ -66,6 +67,7 @@ GetOptions("gtf=s" => \$gtfF,
     "star" => \$star,
     "star-path=s" => \$star_path,
     "star-sjdboverhang=i" => \$star_sjdboverhang,
+    "star-ramlimit" => \$star_ramlimit, ## for STAR, the limit of RAM to use for building genome indices, in bytes
     "hisat2-hca" =>\$hisat2_hca,
     "hisat2-path=s" => \$hisat2_path,
     "p|num-threads=i" => \$nthreads,
@@ -182,7 +184,12 @@ if ($bowtie2) {
 
 if ($star) {
     pod2usage(-msg => "Sorry, if you want RSEM run STAR for you, you must provide the genome sequence and associated GTF annotation.", -exitval => 2, -verbose => 2) if ($gtfF eq "");
-    
+
+    # Ensure star_ramlimit is set to default if not provided by user
+    if (!defined($star_ramlimit) || $star_ramlimit eq '' || $star_ramlimit !~ /^\d+$/) {
+        $star_ramlimit = '31000000000';
+    }
+
     my $out_star_genome_path = dirname($ARGV[1]);
     $command = $star_path . "STAR " .
                         " --runThreadN $nthreads " .
@@ -190,6 +197,7 @@ if ($star) {
                         " --genomeDir $out_star_genome_path " .
                         " --genomeFastaFiles @list " .
                         " --sjdbGTFfile $gtfF " .
+                        " --limitGenomeGenerateRAM $star_ramlimit " .
                         " --sjdbOverhang $star_sjdboverhang " .
                         " --outFileNamePrefix $ARGV[1]";
     &runCommand($command);
@@ -356,6 +364,10 @@ Build STAR indices. (Default: off)
 =item B<--star-path> <path>
 
 The path to STAR's executable. (Default: the path to STAR executable is assumed to be in user's PATH environment variable)
+
+=item B<--star-ramlimit> <int>
+
+Maximum available RAM (bytes) for STAR index generation. (Default: 31000000000)
 
 =item B<--star-sjdboverhang> <int>
 

--- a/rsem-prepare-reference
+++ b/rsem-prepare-reference
@@ -68,8 +68,8 @@ GetOptions("gtf=s" => \$gtfF,
     "star" => \$star,
     "star-path=s" => \$star_path,
     "star-sjdboverhang=i" => \$star_sjdboverhang,
-    "star-ramlimit=i" => \$star_ramlimit, ## for STAR, the limit of RAM to use for building genome indices, in bytes
-    "star-genomeSAindexNbases=i", ## for STAR, the number of bases in SA index, default is 14, which is enough for most genomes
+    "star-ramlimit=i" => \$star_ramlimit,
+    "star-genomeSAindexNbases=i" => \$star_genomeSAindexNbases,
     "hisat2-hca" =>\$hisat2_hca,
     "hisat2-path=s" => \$hisat2_path,
     "p|num-threads=i" => \$nthreads,
@@ -192,6 +192,7 @@ if ($star) {
         $star_ramlimit = '31000000000';
     }
     
+    # Ensure star_sjdboverhang is set to default if not provided by user
     if (!defined($star_genomeSAindexNbases) || $star_genomeSAindexNbases eq '' || $star_genomeSAindexNbases !~ /^\d+$/) {
         $star_genomeSAindexNbases = '14';
     }
@@ -379,6 +380,10 @@ Maximum available RAM (bytes) for STAR index generation. (Default: 31000000000)
 =item B<--star-sjdboverhang> <int>
 
 Length of the genomic sequence around annotated junction. It is only used for STAR to build splice junctions database and not needed for Bowtie or Bowtie2. It will be passed as the --sjdbOverhang option to STAR. According to STAR's manual, its ideal value is max(ReadLength)-1, e.g. for 2x101 paired-end reads, the ideal value is 101-1=100. In most cases, the default value of 100 will work as well as the ideal value. (Default: 100)
+
+=item B<--star-genomeSAindexNbases> <int>
+
+Length (bases) of the SA pre-indexing string. Typically between 10 and 15. Longer strings will use much more memory, but allow faster searches. For small genomes, the parameter must be scaled down to min(14, log2(GenomeLength)/2 - 1).
 
 =item B<--hisat2-hca>
 

--- a/rsem-prepare-reference
+++ b/rsem-prepare-reference
@@ -67,7 +67,7 @@ GetOptions("gtf=s" => \$gtfF,
     "star" => \$star,
     "star-path=s" => \$star_path,
     "star-sjdboverhang=i" => \$star_sjdboverhang,
-    "star-ramlimit" => \$star_ramlimit, ## for STAR, the limit of RAM to use for building genome indices, in bytes
+    "star-ramlimit=i" => \$star_ramlimit, ## for STAR, the limit of RAM to use for building genome indices, in bytes
     "hisat2-hca" =>\$hisat2_hca,
     "hisat2-path=s" => \$hisat2_path,
     "p|num-threads=i" => \$nthreads,

--- a/rsem-prepare-reference
+++ b/rsem-prepare-reference
@@ -44,6 +44,7 @@ my $star = 0;
 my $star_path = '';
 my $star_sjdboverhang = 100;
 my $star_ramlimit = ''; ## for STAR, the limit of RAM to use for building genome indices, in bytes. Default is 31GB, set below which is enough for most genomes.
+my $star_genomeSAindexNbases = ''; ## for STAR, the number of bases in SA index, default is 14, which is enough for most genomes
 
 my $hisat2_hca = 0;
 my $hisat2_path = '';
@@ -68,6 +69,7 @@ GetOptions("gtf=s" => \$gtfF,
     "star-path=s" => \$star_path,
     "star-sjdboverhang=i" => \$star_sjdboverhang,
     "star-ramlimit=i" => \$star_ramlimit, ## for STAR, the limit of RAM to use for building genome indices, in bytes
+    "star-genomeSAindexNbases=i", ## for STAR, the number of bases in SA index, default is 14, which is enough for most genomes
     "hisat2-hca" =>\$hisat2_hca,
     "hisat2-path=s" => \$hisat2_path,
     "p|num-threads=i" => \$nthreads,
@@ -189,6 +191,10 @@ if ($star) {
     if (!defined($star_ramlimit) || $star_ramlimit eq '' || $star_ramlimit !~ /^\d+$/) {
         $star_ramlimit = '31000000000';
     }
+    
+    if (!defined($star_genomeSAindexNbases) || $star_genomeSAindexNbases eq '' || $star_genomeSAindexNbases !~ /^\d+$/) {
+        $star_genomeSAindexNbases = '14';
+    }
 
     my $out_star_genome_path = dirname($ARGV[1]);
     $command = $star_path . "STAR " .
@@ -198,6 +204,7 @@ if ($star) {
                         " --genomeFastaFiles @list " .
                         " --sjdbGTFfile $gtfF " .
                         " --limitGenomeGenerateRAM $star_ramlimit " .
+                        " --genomeSAindexNbases $star_genomeSAindexNbases " .
                         " --sjdbOverhang $star_sjdboverhang " .
                         " --outFileNamePrefix $ARGV[1]";
     &runCommand($command);


### PR DESCRIPTION
Add STAR build options: `--limitGenomeGenerateRAM` and `--genomeSAindexNbases`. These additions provide options for users in #135, #147, and others (https://github.com/nf-core/rnaseq/issues/511), who wish to use `rsem-prepare-reference` with `--star` but encounter errors due to genome size etc. 