### PR TITLE
Modernize-Sprintf

### DIFF
--- a/EM.cpp
+++ b/EM.cpp
@@ -124,7 +124,7 @@ void init(ReadReader<ReadType> **&readers, HitContainer<HitType> **&hitvs, doubl
 		hitvs[i] = new HitContainer<HitType>();
 	}
 
-	sprintf(datF, "%s.dat", imdName);
+	snprintf(datF, sizeof(datF), "%s.dat", imdName);
 	fin.open(datF);
 	general_assert(fin.is_open(), "Cannot open " + cstrtos(datF) + "! It may not exist.");
 	fin>>nReads>>nHits>>rt;
@@ -279,7 +279,7 @@ void* calcConProbs(void* arg) {
 
 template<class ModelType>
 void writeResults(ModelType& model, double* counts) {
-  sprintf(modelF, "%s.model", statName);
+  snprintf(modelF, sizeof(modelF), "%s.model", statName);
   model.write(modelF);
   writeResultsEM(M, refName, imdName, transcripts, theta, eel, countvs[0], appendNames);
 }
@@ -432,7 +432,7 @@ void EM() {
 		}
 		model.setNeedCalcConPrb(false);
 
-		sprintf(out_for_gibbs_F, "%s.ofg", imdName);
+		snprintf(out_for_gibbs_F, sizeof(out_for_gibbs_F), "%s.ofg", imdName);
 		ofstream fout(out_for_gibbs_F);
 		fout<< M<< " "<< N0<< endl;
 		for (int i = 0; i < nThreads; i++) {
@@ -481,7 +481,7 @@ void EM() {
 	pthread_attr_destroy(&attr);
 
 
-	sprintf(thetaF, "%s.theta", statName);
+	snprintf(thetaF, sizeof(thetaF), "%s.theta", statName);
 	fo = fopen(thetaF, "w");
 	fprintf(fo, "%d\n", M + 1);
 
@@ -502,7 +502,7 @@ void EM() {
 	writeResults<ModelType>(model, countvs[0]);
 
 	if (genBamF) {
-		sprintf(outBamF, "%s.transcript.bam", outName);
+		snprintf(outBamF, sizeof(outBamF), "%s.transcript.bam", outName);
 		
 		if (bamSampling) {
 			READ_INT_TYPE local_N;
@@ -597,14 +597,14 @@ int main(int argc, char* argv[]) {
 	general_assert(nThreads > 0, "Number of threads should be bigger than 0!");
 
 	//basic info loading
-	sprintf(refF, "%s.seq", refName);
+	snprintf(refF, sizeof(refF), "%s.seq", refName);
 	refs.loadRefs(refF);
 	M = refs.getM();
 
-	sprintf(tiF, "%s.ti", refName);
+	snprintf(tiF, sizeof(tiF), "%s.ti", refName);
 	transcripts.readFrom(tiF);
 
-	sprintf(cntF, "%s.cnt", statName);
+	snprintf(cntF, sizeof(cntF), "%s.cnt", statName);
 	fin.open(cntF);
 
 	general_assert(fin.is_open(), "Cannot open " + cstrtos(cntF) + "! It may not exist.");
@@ -616,10 +616,10 @@ int main(int argc, char* argv[]) {
 		printf("Warning: There are no alignable reads!\n");
 		theta.resize(M + 1, 0.0);
 		FILE *fo = NULL;
-		sprintf(thetaF, "%s.theta", statName);
+		snprintf(thetaF, sizeof(thetaF), "%s.theta", statName);
 		fo = fopen(thetaF, "w");
 		fclose(fo);
-		sprintf(modelF, "%s.model", statName);
+		snprintf(modelF, sizeof(modelF), "%s.model", statName);
 		fo = fopen(modelF, "w");
 		fclose(fo);
 		eel.resize(M + 1, 0.0);
@@ -628,9 +628,9 @@ int main(int argc, char* argv[]) {
 		memset(countv, 0, sizeof(double) * (M + 1));
 		writeResultsEM(M, refName, imdName, transcripts, theta, eel, countv, appendNames);
 		if (genBamF) {
-			sprintf(outBamF, "%s.transcript.bam", outName);
+			snprintf(outBamF, sizeof(outBamF), "%s.transcript.bam", outName);
 			char command[1005];
-			sprintf(command, "cp %s %s", inpSamF, outBamF);
+			snprintf(command, sizeof(command), "cp %s %s", inpSamF, outBamF);
 			printf("%s\n", command);
 			system(command);
 		}
@@ -644,7 +644,7 @@ int main(int argc, char* argv[]) {
 		mparams.N[0] = N0; mparams.N[1] = N1; mparams.N[2] = N2;
 		mparams.refs = &refs;
 
-		sprintf(mparamsF, "%s.mparams", imdName);
+		snprintf(mparamsF, sizeof(mparamsF), "%s.mparams", imdName);
 		fin.open(mparamsF);
 
 		general_assert(fin.is_open(), "Cannot open " + cstrtos(mparamsF) + "It may not exist.");

--- a/EM.cpp
+++ b/EM.cpp
@@ -629,7 +629,7 @@ int main(int argc, char* argv[]) {
 		writeResultsEM(M, refName, imdName, transcripts, theta, eel, countv, appendNames);
 		if (genBamF) {
 			snprintf(outBamF, sizeof(outBamF), "%s.transcript.bam", outName);
-			char command[1005];
+			char command[STRLEN];
 			snprintf(command, sizeof(command), "cp %s %s", inpSamF, outBamF);
 			printf("%s\n", command);
 			system(command);

--- a/Gibbs.cpp
+++ b/Gibbs.cpp
@@ -104,12 +104,12 @@ void load_data(char* refName, char* statName, char* imdName) {
 	int tmpVal;
 
 	//load reference file
-	sprintf(refF, "%s.seq", refName);
+	snprintf(refF, sizeof(refF), "%s.seq", refName);
 	refs.loadRefs(refF, 1);
 	M = refs.getM();
 
 	//load ofgF;
-	sprintf(ofgF, "%s.ofg", imdName);
+	snprintf(ofgF, sizeof(ofgF), "%s.ofg", imdName);
 	fin.open(ofgF);
 	general_assert(fin.is_open(), "Cannot open " + cstrtos(ofgF) + "!");
 	fin>>tmpVal>>N0;
@@ -138,7 +138,7 @@ void load_data(char* refName, char* statName, char* imdName) {
 
 void load_group_info(char* refName) {
   // Load group info
-  sprintf(groupF, "%s.grp", refName);
+  snprintf(groupF, sizeof(groupF), "%s.grp", refName);
   gi.load(groupF);
   m = gi.getm();
   
@@ -154,7 +154,7 @@ void load_omit_info(const char* imdName) {
   FILE *fi = NULL;
   int tid;
   
-  sprintf(omitF, "%s.omit", imdName);
+  snprintf(omitF, sizeof(omitF), "%s.omit", imdName);
   fi = fopen(omitF, "r");
   init_counts.assign(M + 1, 0);
   totc = M + 1;
@@ -211,7 +211,7 @@ void init() {
 	quotient = NSAMPLES / nThreads;
 	left = NSAMPLES % nThreads;
 
-	sprintf(cvsF, "%s.countvectors", imdName);
+	snprintf(cvsF, sizeof(cvsF), "%s.countvectors", imdName);
 	paramsArray = new Params[nThreads];
 	threads = new pthread_t[nThreads];
 
@@ -222,7 +222,7 @@ void init() {
 		paramsArray[i].nsamples = quotient;
 		if (i < left) paramsArray[i].nsamples++;
 
-		sprintf(outF, "%s%d", cvsF, i);
+		snprintf(outF, sizeof(outF), "%s%d", cvsF, i);
 		paramsArray[i].fo = fopen(outF, "w");
 
 		paramsArray[i].engine = engineFactory::new_engine();
@@ -492,7 +492,7 @@ int main(int argc, char* argv[]) {
 	}
 	//////
 
-	sprintf(modelF, "%s.model", statName);
+	snprintf(modelF, sizeof(modelF), "%s.model", statName);
 	FILE *fi = fopen(modelF, "r");
 	general_assert(fi != NULL, "Cannot open " + cstrtos(modelF) + "!");
 	assert(fscanf(fi, "%d", &model_type) == 1);

--- a/ReadIndex.h
+++ b/ReadIndex.h
@@ -22,7 +22,7 @@ struct ReadIndex {
 		char indexF[STRLEN];
 		std::ifstream fin;
 
-		sprintf(indexF, "%s.ridx", readF);
+		snprintf(indexF, sizeof(indexF), "%s.ridx", readF);
 		fin.open(indexF, std::ios::binary);
 		if (!fin.is_open()) { fprintf(stderr, "Cannot open %s! It may not exist.\n", indexF); exit(-1); }
 

--- a/Transcripts.h
+++ b/Transcripts.h
@@ -134,7 +134,7 @@ void Transcripts::buildMappings(int n_targets, char** target_name, const char* i
 
 	if (imdName != NULL) {
 	  char omitF[STRLEN];
-	  sprintf(omitF, "%s.omit", imdName);
+	  snprintf(omitF, sizeof(omitF), "%s.omit", imdName);
 	  FILE *fo = fopen(omitF, "w");
 	  for (int i = 1; i <= M; i++) 
 	    if (!appeared[i]) fprintf(fo, "%d\n", i);

--- a/WriteResults.h
+++ b/WriteResults.h
@@ -107,8 +107,8 @@ inline bool isAlleleSpecific(const char* refName, GroupInfo* gt = NULL, GroupInf
   bool alleleS;
   char gtF[STRLEN], taF[STRLEN];
 
-  sprintf(gtF, "%s.gt", refName);
-  sprintf(taF, "%s.ta", refName);
+  snprintf(gtF, sizeof(gtF), "%s.gt", refName);
+  snprintf(taF, sizeof(taF), "%s.ta", refName);
   std::ifstream gtIF(gtF), taIF(taF);
   alleleS = gtIF.is_open() && taIF.is_open();
   if (gtIF.is_open()) gtIF.close();
@@ -135,7 +135,7 @@ void writeResultsEM(int M, const char* refName, const char* imdName, Transcripts
 	std::vector<double> glens, gene_eels, gene_counts, gene_tpm, gene_fpkm;
 	
 	// Load group info
-	sprintf(groupF, "%s.grp", refName);
+	snprintf(groupF, sizeof(groupF), "%s.grp", refName);
 	gi.load(groupF);
 	m = gi.getm();
 
@@ -222,7 +222,7 @@ void writeResultsEM(int M, const char* refName, const char* imdName, Transcripts
 
 	if (!alleleS) {
 	  //isoform level results
-	  sprintf(outF, "%s.iso_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.iso_res", imdName);
 	  fo = fopen(outF, "w");
 	  for (int i = 1; i <= M; i++) {
 	    const Transcript& transcript = transcripts.getTranscriptAt(i);
@@ -256,7 +256,7 @@ void writeResultsEM(int M, const char* refName, const char* imdName, Transcripts
 	}
 	else {
 	  // allele level results
-	  sprintf(outF, "%s.allele_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.allele_res", imdName);
 	  fo = fopen(outF, "w");
 	  for (int i = 1; i <= M; i++) {
 	    const Transcript& transcript = transcripts.getTranscriptAt(i);
@@ -287,7 +287,7 @@ void writeResultsEM(int M, const char* refName, const char* imdName, Transcripts
 	  fclose(fo);
 
 	  // isoform level results
-	  sprintf(outF, "%s.iso_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.iso_res", imdName);
 	  fo = fopen(outF, "w");
 	  for (int i = 0; i < m_trans; i++) {
 	    const Transcript& transcript = transcripts.getTranscriptAt(ta.spAt(i));
@@ -313,7 +313,7 @@ void writeResultsEM(int M, const char* refName, const char* imdName, Transcripts
 	}
 
 	//gene level results
-	sprintf(outF, "%s.gene_res", imdName);
+	snprintf(outF, sizeof(outF), "%s.gene_res", imdName);
 	fo = fopen(outF, "w");
 	for (int i = 0; i < m; i++) {
 		const Transcript& transcript = transcripts.getTranscriptAt(gi.spAt(i));
@@ -406,7 +406,7 @@ void writeResultsGibbs(int M, int m, int m_trans, GroupInfo& gi, GroupInfo &gt, 
 
 	if (!alleleS) {
 	  //isoform level results
-	  sprintf(outF, "%s.iso_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.iso_res", imdName);
 	  fo = fopen(outF, "a");
 	  general_assert(fo != NULL, "Cannot open " + cstrtos(outF) + "!");
 	  
@@ -424,7 +424,7 @@ void writeResultsGibbs(int M, int m, int m_trans, GroupInfo& gi, GroupInfo &gt, 
 	}
 	else {
 	  //allele level results
-	  sprintf(outF, "%s.allele_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.allele_res", imdName);
 	  fo = fopen(outF, "a");
 	  general_assert(fo != NULL, "Cannot open " + cstrtos(outF) + "!");
 	  
@@ -443,7 +443,7 @@ void writeResultsGibbs(int M, int m, int m_trans, GroupInfo& gi, GroupInfo &gt, 
 	  fclose(fo);
 
 	  //isoform level results
-	  sprintf(outF, "%s.iso_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.iso_res", imdName);
 	  fo = fopen(outF, "a");
 	  general_assert(fo != NULL, "Cannot open " + cstrtos(outF) + "!");
 	  
@@ -461,7 +461,7 @@ void writeResultsGibbs(int M, int m, int m_trans, GroupInfo& gi, GroupInfo &gt, 
 	}
  
 	//gene level results
-	sprintf(outF, "%s.gene_res", imdName);
+	snprintf(outF, sizeof(outF), "%s.gene_res", imdName);
 	fo = fopen(outF, "a");
 	general_assert(fo != NULL, "Cannot open " + cstrtos(outF) + "!");
 
@@ -487,7 +487,7 @@ void writeResultsSimulation(int M, char* refName, char* outFN, Transcripts& tran
 	char groupF[STRLEN];
 
         // Load group info
-        sprintf(groupF, "%s.grp", refName);
+        snprintf(groupF, sizeof(groupF), "%s.grp", refName);
         gi.load(groupF);
 	m = gi.getm();
 
@@ -581,7 +581,7 @@ void writeResultsSimulation(int M, char* refName, char* outFN, Transcripts& tran
 
 	//allele level
 	if (alleleS) {
-	  sprintf(outF, "%s.sim.alleles.results", outFN);
+	  snprintf(outF, sizeof(outF), "%s.sim.alleles.results", outFN);
 	  fo = fopen(outF, "w");
 	  fprintf(fo, "allele_id\ttranscript_id\tgene_id\tlength\teffective_length\tcount\tTPM\tFPKM\tAlleleIsoPct\tAlleleGenePct\n");
 	  for (int i = 1; i <= M; i++) {
@@ -593,7 +593,7 @@ void writeResultsSimulation(int M, char* refName, char* outFN, Transcripts& tran
 	}
 
 	//isoform level
-	sprintf(outF, "%s.sim.isoforms.results", outFN);
+	snprintf(outF, sizeof(outF), "%s.sim.isoforms.results", outFN);
 	fo = fopen(outF, "w");
 	fprintf(fo, "transcript_id\tgene_id\tlength\teffective_length\tcount\tTPM\tFPKM\tIsoPct\n");
 	if (!alleleS) {
@@ -613,7 +613,7 @@ void writeResultsSimulation(int M, char* refName, char* outFN, Transcripts& tran
 	fclose(fo);
 
 	//gene level
-	sprintf(outF, "%s.sim.genes.results", outFN);
+	snprintf(outF, sizeof(outF), "%s.sim.genes.results", outFN);
 	fo = fopen(outF, "w");
 	fprintf(fo, "gene_id\ttranscript_id(s)\tlength\teffective_length\tcount\tTPM\tFPKM\n");
 	for (int i = 0; i < m; i++) {

--- a/buildReadIndex.cpp
+++ b/buildReadIndex.cpp
@@ -22,7 +22,7 @@ void buildIndex(char* readF, int gap, bool hasQ) {
 	char buf[sizeof(nReads) + sizeof(gap) + sizeof(nPos)];
 	streampos startPos;
 
-	sprintf(idxF, "%s.ridx", readF);
+	snprintf(idxF, sizeof(idxF), "%s.ridx", readF);
 
 	ifstream fin(readF);
 	if (!fin.is_open()) { fprintf(stderr, "Cannot open %s! It may not exist.\n", readF); exit(-1); }

--- a/calcCI.cpp
+++ b/calcCI.cpp
@@ -180,7 +180,7 @@ void sample_theta_vectors_from_count_vectors() {
 	hasSeed ? engineFactory::init(seed) : engineFactory::init();
 	for (int i = 0; i < num_threads; i++) {
 		paramsArray[i].no = i;
-		sprintf(inpF, "%s%d", cvsF, i);
+		snprintf(inpF, sizeof(inpF), "%s%d", cvsF, i);
 		paramsArray[i].fi = fopen(inpF, "r");
 		paramsArray[i].engine = engineFactory::new_engine();
 		paramsArray[i].mw = model.getMW();
@@ -443,7 +443,7 @@ void calculate_credibility_intervals(char* imdName) {
 
 	delete[] ciParamsArray;
 
-	alleleS ? sprintf(outF, "%s.allele_res", imdName) : sprintf(outF, "%s.iso_res", imdName);
+	alleleS ? snprintf(outF, sizeof(outF), "%s.allele_res", imdName) : snprintf(outF, sizeof(outF), "%s.iso_res", imdName);
 	fo = fopen(outF, "a");
 	for (int i = 1; i <= M; i++)
 	  fprintf(fo, "%.6g%c", tpm[i].lb, (i < M ? '\t' : '\n'));
@@ -461,7 +461,7 @@ void calculate_credibility_intervals(char* imdName) {
 
 	if (alleleS) {
 	  //isoform level results
-	  sprintf(outF, "%s.iso_res", imdName);
+	  snprintf(outF, sizeof(outF), "%s.iso_res", imdName);
 	  fo = fopen(outF, "a");
 	  for (int i = 0; i < m_trans; i++)
 	    fprintf(fo, "%.6g%c", iso_tpm[i].lb, (i < m_trans - 1 ? '\t' : '\n'));
@@ -479,7 +479,7 @@ void calculate_credibility_intervals(char* imdName) {
 	}
 
 	//gene level results
-	sprintf(outF, "%s.gene_res", imdName);
+	snprintf(outF, sizeof(outF), "%s.gene_res", imdName);
 	fo = fopen(outF, "a");
 	for (int i = 0; i < m; i++)
 	  fprintf(fo, "%.6g%c", gene_tpm[i].lb, (i < m - 1 ? '\t' : '\n'));
@@ -539,11 +539,11 @@ int main(int argc, char* argv[]) {
 	}
 	verbose = !quiet;
 
-	sprintf(refF, "%s.seq", refName);
+	snprintf(refF, sizeof(refF), "%s.seq", refName);
 	refs.loadRefs(refF, 1);
 	M = refs.getM();
 
-	sprintf(groupF, "%s.grp", refName);
+	snprintf(groupF, sizeof(groupF), "%s.grp", refName);
 	gi.load(groupF);
 	m = gi.getm();
 
@@ -555,10 +555,10 @@ int main(int argc, char* argv[]) {
 	assert(nSamples > 0 && M > 0); // for Buffter.h: (bufsize_type)nSamples
 	l_bars = new float[nSamples];
 
-	sprintf(tmpF, "%s.tmp", imdName);
-	sprintf(cvsF, "%s.countvectors", imdName);
+	snprintf(tmpF, sizeof(tmpF), "%s.tmp", imdName);
+	snprintf(cvsF, sizeof(cvsF), "%s.countvectors", imdName);
 
-	sprintf(modelF, "%s.model", statName);
+	snprintf(modelF, sizeof(modelF), "%s.model", statName);
 	FILE *fi = fopen(modelF, "r");
 	general_assert(fi != NULL, "Cannot open " + cstrtos(modelF) + "!");
 	assert(fscanf(fi, "%d", &model_type) == 1);

--- a/extractRef.cpp
+++ b/extractRef.cpp
@@ -257,10 +257,10 @@ void writeResults(char* refName) {
 	int s;
 	ofstream fout;
 
-	sprintf(groupF, "%s.grp", refName);
-	sprintf(tiF, "%s.ti", refName);
-	sprintf(refFastaF, "%s.transcripts.fa", refName);
-	sprintf(chromListF, "%s.chrlist", refName);
+	snprintf(groupF, sizeof(groupF), "%s.grp", refName);
+	snprintf(tiF, sizeof(tiF), "%s.ti", refName);
+	snprintf(refFastaF, sizeof(refFastaF), "%s.transcripts.fa", refName);
+	snprintf(chromListF, sizeof(chromListF), "%s.chrlist", refName);
 
 
 	fout.open(groupF);

--- a/parseIt.cpp
+++ b/parseIt.cpp
@@ -182,13 +182,13 @@ int main(int argc, char* argv[]) {
 	  }
 	}
 
-	sprintf(groupF, "%s.grp", argv[1]);
+	snprintf(groupF, sizeof(groupF), "%s.grp", argv[1]);
 	gi.load(groupF);
-	sprintf(tiF, "%s.ti", argv[1]);
+	snprintf(tiF, sizeof(tiF), "%s.ti", argv[1]);
 	transcripts.readFrom(tiF);
 
-	sprintf(datF, "%s.dat", argv[2]);
-	sprintf(cntF, "%s.cnt", argv[3]);
+	snprintf(datF, sizeof(datF), "%s.dat", argv[2]);
+	snprintf(cntF, sizeof(cntF), "%s.cnt", argv[3]);
 
 	init(argv[2], argv[4]);
 

--- a/preRef.cpp
+++ b/preRef.cpp
@@ -67,10 +67,10 @@ int main(int argc, char* argv[]) {
 	M = refs.getM();
 
 	//save references
-	sprintf(refF, "%s.seq", argv[3]);
+	snprintf(refF, sizeof(refF), "%s.seq", argv[3]);
 	refs.saveRefs(refF);
 
-	sprintf(idxF, "%s.idx.fa", argv[3]);
+	snprintf(idxF, sizeof(idxF), "%s.idx.fa", argv[3]);
 	fout.open(idxF);
 	for (int i = 1; i <= M; i++) {
 		fout<< ">"<< refs.getRef(i).getName()<< endl<< refs.getRef(i).getSeq()<< endl;
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
 	fout.close();
 	if (verbose) printf("%s is generated!\n", idxF);
 
-	sprintf(n2g_idxF, "%s.n2g.idx.fa", argv[3]);
+	snprintf(n2g_idxF, sizeof(n2g_idxF), "%s.n2g.idx.fa", argv[3]);
 	fout.open(n2g_idxF);
 	for (int i = 1; i <= M; i++) {
 	  fout<< ">"<< refs.getRef(i).getName()<< endl<< aligner_refp.convert(refs.getRef(i).getSeq())<< endl;

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -61,21 +61,21 @@ void genOutReadStreams(int type, char *outFN) {
 	switch(type) {
 	case 0 :
 		n_os = 1;
-		sprintf(outReadF[0], "%s.fa", outFN);
+		snprintf(outReadF[0], sizeof(outReadF[0]), "%s.fa", outFN);
 		break;
 	case 1 :
 		n_os = 1;
-		sprintf(outReadF[0], "%s.fq", outFN);
+		snprintf(outReadF[0], sizeof(outReadF[0]), "%s.fq", outFN);
 		break;
 	case 2 :
 		n_os = 2;
 		for (int i = 0; i < n_os; i++)
-			sprintf(outReadF[i], "%s_%d.fa", outFN, i + 1);
+			snprintf(outReadF[i], sizeof(outReadF[i]), "%s_%d.fa", outFN, i + 1);
 		break;
 	case 3 :
 		n_os = 2;
 		for (int i = 0; i < n_os; i++)
-			sprintf(outReadF[i], "%s_%d.fq", outFN, i + 1);
+			snprintf(outReadF[i], sizeof(outReadF[i]), "%s_%d.fq", outFN, i + 1);
 		break;
 	}
 
@@ -190,10 +190,10 @@ int main(int argc, char* argv[]) {
 	OFFSITE = (alleleS ? 6: 5);
 
 	//load basic files
-	sprintf(refF, "%s.seq", argv[1]);
+	snprintf(refF, sizeof(refF), "%s.seq", argv[1]);
 	refs.loadRefs(refF);
 	M = refs.getM();
-	sprintf(tiF, "%s.ti", argv[1]);
+	snprintf(tiF, sizeof(tiF), "%s.ti", argv[1]);
 	transcripts.readFrom(tiF);
 
 	//read model type from modelF

--- a/synthesisRef.cpp
+++ b/synthesisRef.cpp
@@ -74,7 +74,7 @@ void writeResults(int option, char* refName) {
 	string cur_gene_id, cur_transcript_id, name;
 	vector<int> gi, gt, ta;
 
-	sprintf(tiF, "%s.ti", refName);
+	snprintf(tiF, sizeof(tiF), "%s.ti", refName);
 	transcripts.writeTo(tiF);
 	if (verbose) { printf("Transcript Information File is generated!\n"); }
 
@@ -95,25 +95,25 @@ void writeResults(int option, char* refName) {
 	gi.push_back(M + 1);
 	if (option == 2) { gt.push_back((int)ta.size()); ta.push_back(M + 1); }
 
-	sprintf(groupF, "%s.grp", refName);
+	snprintf(groupF, sizeof(groupF), "%s.grp", refName);
 	fout.open(groupF);
 	for (int i = 0; i < (int)gi.size(); i++) fout<< gi[i]<< endl;
 	fout.close();
 	if (verbose) { printf("Group File is generated!\n"); }
 
 	if (option == 2) {
-	  sprintf(gtF, "%s.gt", refName);
+	  snprintf(gtF, sizeof(gtF), "%s.gt", refName);
 	  fout.open(gtF);
 	  for (int i = 0; i < (int)gt.size(); i++) fout<< gt[i]<< endl;
 	  fout.close();
-	  sprintf(taF, "%s.ta", refName);
+	  snprintf(taF, sizeof(taF), "%s.ta", refName);
 	  fout.open(taF);
 	  for (int i = 0; i < (int)ta.size(); i++) fout<< ta[i]<< endl;
 	  fout.close();
 	  if (verbose) { printf("Allele-specific group files are generated!\n"); }
 	}
 
-	sprintf(refFastaF, "%s.transcripts.fa", refName);
+	snprintf(refFastaF, sizeof(refFastaF), "%s.transcripts.fa", refName);
 	fout.open(refFastaF);
 	for (int i = 1; i <= M; i++) {
 		name = transcripts.getTranscriptAt(i).getSeqName();

--- a/tbam2gbam.cpp
+++ b/tbam2gbam.cpp
@@ -22,8 +22,8 @@ int main(int argc, char* argv[]) {
         nThreads = 1; // default is 1
         if (argc == 6) { assert(strcmp(argv[4], "-p") == 0); nThreads = atoi(argv[5]); }
 
-	sprintf(tiF, "%s.ti", argv[1]);
-	sprintf(chr_list, "%s.chrlist", argv[1]);
+	snprintf(tiF, sizeof(tiF), "%s.ti", argv[1]);
+	snprintf(chr_list, sizeof(chr_list), "%s.chrlist", argv[1]);
 	transcripts.readFrom(tiF);
 
 	printf("Start converting:\n");

--- a/utils.h
+++ b/utils.h
@@ -139,12 +139,12 @@ inline void genReadFileNames(const char* readFN, int tagType, int read_type, int
 
 	if (read_type == 0 || read_type == 1) {
 		s = 1;
-		sprintf(readFs[0], "%s_%s.%s", readFN, tags[tagType], suffix);
+		snprintf(readFs[0], sizeof(readFs[0]), "%s_%s.%s", readFN, tags[tagType], suffix);
 	}
 	else {
 		s = 2;
-		sprintf(readFs[0], "%s_%s_1.%s", readFN, tags[tagType], suffix);
-		sprintf(readFs[1], "%s_%s_2.%s", readFN, tags[tagType], suffix);
+		snprintf(readFs[0], sizeof(readFs[0]), "%s_%s_1.%s", readFN, tags[tagType], suffix);
+		snprintf(readFs[1], sizeof(readFs[1]), "%s_%s_2.%s", readFN, tags[tagType], suffix);
 	}
 }
 


### PR DESCRIPTION
## What

Replaces every `sprintf` call in RSEM's core C++ with `snprintf`, bounded by the
destination's own size. 74 call sites across 14 files. 
Vendored code (`samtools-1.3/`, `boost/`, `EBSeq/`, `pRSEM/`) is untouched.

## Why it's needed

`sprintf` has no bound on what it writes. Most of these sites build output paths
by concatenating user-supplied sample/output names into a fixed `char[STRLEN]`
buffer, so a long enough path silently overruns it. `snprintf` truncates instead.

## Files Touched

`EM.cpp` `Gibbs.cpp` `ReadIndex.h` `Transcripts.h` `WriteResults.h`
`buildReadIndex.cpp` `calcCI.cpp` `extractRef.cpp` `parseIt.cpp` `preRef.cpp`
`simulation.cpp` `synthesisRef.cpp` `tbam2gbam.cpp` `utils.h`

## Verification

Every site uses `snprintf(dst, sizeof(dst), ...)`. All 74 were audited to confirm
`dst` is a true in-scope array, never a decayed pointer — the one way this
refactor could silently introduce truncation.

- `make all` clean, exit 0, zero warnings from RSEM's own sources under `-Wall`.
- Ran the `test-suite` branch's gold-output suite against this diff: **16/16
  runnable targets pass** — hisat2 and STAR × single/paired end ×
  {prepare-reference, calculate-expression, calculate-expression-ci,
  simulate-reads}, plus the `hisat2_path` and `star_gzip_genomebam` option cases.
  bowtie/bowtie2 lanes were not run locally (bowtie not installed).
- `synthesisRef.cpp` and `tbam2gbam.cpp` have no gold coverage in the suite;
  both were exercised manually (`rsem-prepare-reference` without `--gtf`, and
  `--output-genome-bam`) — exit 0, output sane.
